### PR TITLE
- Build process for Percona-TokuBackup generates tags file.

### DIFF
--- a/backup/.gitignore
+++ b/backup/.gitignore
@@ -1,3 +1,4 @@
 Debug
 TAGS
+tags
 *~


### PR DESCRIPTION
  Ignore it as it would change from time to time and no need to track
  it as part of repos.