### PR TITLE
Make USE_VALGRIND default OFF and fix includes for valgrind headers

### DIFF
--- a/backup/CMakeLists.txt
+++ b/backup/CMakeLists.txt
@@ -12,7 +12,7 @@ set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS
 
 set(CMAKE_CXX_FLAGS "-Werror -W -Wall -Wshadow ${CMAKE_CXX_FLAGS}")
 
-set(USE_VALGRIND ON CACHE BOOL "whether to use valgrind headers")
+set(USE_VALGRIND OFF CACHE BOOL "whether to use valgrind headers")
 if (USE_VALGRIND)
   set_property(DIRECTORY APPEND PROPERTY
     COMPILE_DEFINITIONS BACKUP_USE_VALGRIND=1)

--- a/backup/backup_helgrind.h
+++ b/backup/backup_helgrind.h
@@ -41,6 +41,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
   #define TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(x, y) VALGRIND_HG_DISABLE_CHECKING(x, y)
 #else
   #define TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(x, y) ((void) x, (void) y)
+  #define VALGRIND_HG_DISABLE_CHECKING(x, y) ((void) x, (void) y)
 #endif
 
 #endif  /* BACKUP_HELGPIND_H */

--- a/backup/manager.cc
+++ b/backup/manager.cc
@@ -54,7 +54,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#include <valgrind/helgrind.h>
+#include "backup_helgrind.h"
 
 #if DEBUG_HOTBACKUP
 #define WARN(string, arg) HotBackup::CaptureWarn(string, arg)

--- a/backup/manager_state.cc
+++ b/backup/manager_state.cc
@@ -36,7 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #include <pthread.h>
 
-#include <valgrind/helgrind.h>
+#include "backup_helgrind.h"
 
 #include "manager_state.h"
 

--- a/backup/real_syscalls.cc
+++ b/backup/real_syscalls.cc
@@ -40,7 +40,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include <stdio.h>
 #include <unistd.h>
 #include <pthread.h>
-#include <valgrind/helgrind.h>
+#include "backup_helgrind.h"
 
 #include "real_syscalls.h"
 #include "mutex.h"

--- a/backup/tests/backup_test_helpers.cc
+++ b/backup/tests/backup_test_helpers.cc
@@ -40,7 +40,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <valgrind/helgrind.h>
+#include "backup_helgrind.h"
 
 #include "backup_test_helpers.h"
 #include "backup_internal.h"

--- a/backup/tests/open_write_close.cc
+++ b/backup/tests/open_write_close.cc
@@ -41,7 +41,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include <fcntl.h>
 #include <unistd.h>
 #include <string.h>
-#include <valgrind/helgrind.h>
+#include "backup_helgrind.h"
 
 #include "backup.h"
 #include "backup_test_helpers.h"

--- a/backup/tests/range_locks.cc
+++ b/backup/tests/range_locks.cc
@@ -35,7 +35,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include <limits.h>
 #include <stdio.h>
 #include <unistd.h>
-#include <valgrind/helgrind.h>
+#include "backup_helgrind.h"
 
 #include "backup_test_helpers.h"
 #include "source_file.h"

--- a/backup/tests/realpath_error_injection.cc
+++ b/backup/tests/realpath_error_injection.cc
@@ -41,7 +41,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include <valgrind/helgrind.h>
+#include "backup_helgrind.h"
 
 #include "backup_test_helpers.h"
 #include "real_syscalls.h"


### PR DESCRIPTION
**BUG:**
https://bugs.launchpad.net/percona-server/+bug/1494283

This is basically just for start of work because it needs more discussion.

Purpose:
1. Make USE_VALGRIND default to OFF from TokuBackup
It's default OFF in PerconaFT and here seems it was ON because valgrind includes are not optional.
2. Use backup_helgrind.h since it's already there

Questionable thing:
I see that in most places VALGRIND_HG_DISABLE_CHECKING is used, but in backup_debug.cc TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING is used.
Maybe we should change that one to VALGRIND_HG_DISABLE_CHECKING also and remove define for the TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING one?