### PR TITLE
Rename VALGRIND_HG_DISABLE_CHECKING calls to TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING

### DIFF
--- a/backup/backup_helgrind.h
+++ b/backup/backup_helgrind.h
@@ -41,7 +41,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
   #define TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(x, y) VALGRIND_HG_DISABLE_CHECKING(x, y)
 #else
   #define TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(x, y) ((void) x, (void) y)
-  #define VALGRIND_HG_DISABLE_CHECKING(x, y) ((void) x, (void) y)
 #endif
 
 #endif  /* BACKUP_HELGPIND_H */

--- a/backup/manager.cc
+++ b/backup/manager.cc
@@ -111,13 +111,13 @@ manager::manager(void) throw()
       m_errnum(BACKUP_SUCCESS),
       m_errstring(NULL)
 {
-    VALGRIND_HG_DISABLE_CHECKING(&m_backup_is_running, sizeof(m_backup_is_running));
+    TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(&m_backup_is_running, sizeof(m_backup_is_running));
 #ifdef GLASSBOX
-    VALGRIND_HG_DISABLE_CHECKING(&m_is_capturing, sizeof(m_is_capturing));
-    VALGRIND_HG_DISABLE_CHECKING(&m_done_copying, sizeof(m_done_copying));
-    VALGRIND_HG_DISABLE_CHECKING(&m_an_error_happened, sizeof(m_an_error_happened));
-    VALGRIND_HG_DISABLE_CHECKING(&m_errnum, sizeof(m_errnum));
-    VALGRIND_HG_DISABLE_CHECKING(&m_errstring, sizeof(m_errstring));
+    TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(&m_is_capturing, sizeof(m_is_capturing));
+    TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(&m_done_copying, sizeof(m_done_copying));
+    TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(&m_an_error_happened, sizeof(m_an_error_happened));
+    TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(&m_errnum, sizeof(m_errnum));
+    TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(&m_errstring, sizeof(m_errstring));
 #endif
 }
 
@@ -930,7 +930,7 @@ void manager::mkdir(const char *pathname) throw() {
 ///////////////////////////////////////////////////////////////////////////////
 //
 void manager::set_throttle(unsigned long bytes_per_second) throw() {
-    VALGRIND_HG_DISABLE_CHECKING(&m_throttle, sizeof(m_throttle));
+    TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(&m_throttle, sizeof(m_throttle));
     m_throttle = bytes_per_second;
 }
 
@@ -1057,12 +1057,12 @@ void manager::unlock_file_op(void)
 #ifdef GLASSBOX
 // Test routines.
 void manager::pause_disable(bool pause) throw() {
-    VALGRIND_HG_DISABLE_CHECKING(&m_pause_disable, sizeof(m_pause_disable));
+    TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(&m_pause_disable, sizeof(m_pause_disable));
     m_pause_disable = pause;
 }
 
 void manager::set_keep_capturing(bool keep_capturing) throw() {
-    VALGRIND_HG_DISABLE_CHECKING(&m_keep_capturing, sizeof(m_keep_capturing));
+    TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(&m_keep_capturing, sizeof(m_keep_capturing));
     m_keep_capturing = keep_capturing;
 }
 
@@ -1074,7 +1074,7 @@ bool manager::is_capturing(void) throw() {
 }
 
 void manager::set_start_copying(bool start_copying) throw() {
-    VALGRIND_HG_DISABLE_CHECKING(&m_start_copying, sizeof(m_start_copying));
+    TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(&m_start_copying, sizeof(m_start_copying));
     m_start_copying = start_copying;
 }
 #endif /*GLASSBOX*/

--- a/backup/manager_state.cc
+++ b/backup/manager_state.cc
@@ -45,9 +45,9 @@ manager_state::manager_state() throw()
       m_capture_enabled(false),
       m_copy_enabled(false)
 {
-    VALGRIND_HG_DISABLE_CHECKING(&m_is_dead,         sizeof(m_is_dead));
-    VALGRIND_HG_DISABLE_CHECKING(&m_capture_enabled, sizeof(m_capture_enabled));
-    VALGRIND_HG_DISABLE_CHECKING(&m_copy_enabled,    sizeof(m_copy_enabled));
+    TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(&m_is_dead,         sizeof(m_is_dead));
+    TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(&m_capture_enabled, sizeof(m_capture_enabled));
+    TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(&m_copy_enabled,    sizeof(m_copy_enabled));
 }
 
 bool manager_state::is_dead(void) throw() {

--- a/backup/real_syscalls.cc
+++ b/backup/real_syscalls.cc
@@ -54,7 +54,7 @@ template <class T> static void dlsym_set(T *ptr, const char *name)
 // Rationale:  There were a whole bunch of these through this code, and they all are the same except the type.  Rather than
 //   programming it with macros, I do it in a type-safe way with templates. -Bradley
 {
-    VALGRIND_HG_DISABLE_CHECKING(ptr, sizeof(*ptr));
+    TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(ptr, sizeof(*ptr));
     if (*ptr==NULL) {
         pmutex_lock(&dlsym_mutex); // if things go wrong, what can we do?  We probably cannot even report it.
         if (*ptr==NULL) {
@@ -73,7 +73,7 @@ template <class T> static void dlvsym_set(T *ptr, const char *name, const char *
 // Rationale:  There were a whole bunch of these through this code, and they all are the same except the type.  Rather than
 //   programming it with macros, I do it in a type-safe way with templates. -Bradley
 {
-    VALGRIND_HG_DISABLE_CHECKING(ptr, sizeof(*ptr));
+    TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(ptr, sizeof(*ptr));
     if (*ptr==NULL) {
         pmutex_lock(&dlsym_mutex); // if things go wrong, what can we do?  We probably cannot even report it.
         if (*ptr==NULL) {

--- a/backup/tests/backup_test_helpers.cc
+++ b/backup/tests/backup_test_helpers.cc
@@ -202,7 +202,7 @@ void start_backup_thread_with_funs(pthread_t *thread,
     p->error_fun = error_fun;
     p->error_extra = error_extra;
     p->expect_return_result = expect_return_result;
-    VALGRIND_HG_DISABLE_CHECKING(&backup_is_done, sizeof(backup_is_done));
+    TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(&backup_is_done, sizeof(backup_is_done));
     backup_is_done = false;
     int r = pthread_create(thread, NULL, start_backup_thread_fun, p);
     check(r==0);

--- a/backup/tests/open_write_close.cc
+++ b/backup/tests/open_write_close.cc
@@ -78,7 +78,7 @@ static int write_poll(float progress, const char *progress_string, void *extra) 
 
 //
 static void open_write_close(void) {
-    VALGRIND_HG_DISABLE_CHECKING(&write_done, sizeof(write_done));
+    TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(&write_done, sizeof(write_done));
 
     setup_source();
     setup_dirs();

--- a/backup/tests/range_locks.cc
+++ b/backup/tests/range_locks.cc
@@ -61,9 +61,9 @@ static void* doit(void* ignore) {
 }
 
 static void thread_test_block(void) {
-    VALGRIND_HG_DISABLE_CHECKING(&stepa, sizeof(stepa));
-    VALGRIND_HG_DISABLE_CHECKING(&stepb, sizeof(stepb));
-    VALGRIND_HG_DISABLE_CHECKING(&stepc, sizeof(stepc));
+    TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(&stepa, sizeof(stepa));
+    TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(&stepb, sizeof(stepb));
+    TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(&stepc, sizeof(stepc));
     stepa = stepb = 0;
     pthread_t th;
     char the_char;
@@ -91,9 +91,9 @@ static void thread_test_block(void) {
 }
 
 static void thread_test_noblock(void) {
-    VALGRIND_HG_DISABLE_CHECKING(&stepa, sizeof(stepa));
-    VALGRIND_HG_DISABLE_CHECKING(&stepb, sizeof(stepb));
-    VALGRIND_HG_DISABLE_CHECKING(&stepc, sizeof(stepc));
+    TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(&stepa, sizeof(stepa));
+    TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(&stepb, sizeof(stepb));
+    TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(&stepc, sizeof(stepc));
     stepa = stepb = stepc = 0;
     pthread_t th;
     char the_char;

--- a/backup/tests/realpath_error_injection.cc
+++ b/backup/tests/realpath_error_injection.cc
@@ -120,7 +120,7 @@ char *my_realpath(const char *path, char *result) {
 
 int test_main(int n, const char **p)
 {
-    VALGRIND_HG_DISABLE_CHECKING(&inject_realpath_error, sizeof(inject_realpath_error));
+    TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(&inject_realpath_error, sizeof(inject_realpath_error));
     original_realpath = register_realpath(my_realpath);
 
     n++;


### PR DESCRIPTION
This is to make those calls standardized as discussed in:
https://github.com/percona/Percona-TokuBackup/pull/73

I tried following:
1. build without installed valgrind and without specifying WITH_VALGRIND or USE_VALGRIND
cmake .. -DBUILD_CONFIG=mysql_release -DCMAKE_BUILD_TYPE=RelWithDebInfo
RESULT: OK
2. build without installed valgrind and with WITH_VALGRIND=ON and USE_VALGRIND=ON added
RESULT: OK - Error reported in cmake for dependency
3. build with installed valgrind - and with WITH_VALGRIND=ON and USE_VALGRIND=ON
RESULT: OK

If param build is needed please comment.