### PR TITLE
Increase performance: pass backtrace objects by reference, not by value

### DIFF
--- a/backup/check.cc
+++ b/backup/check.cc
@@ -39,7 +39,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "check.h"
 #include "manager.h"
 
-void check_fun(long predicate, const char *expr, const backtrace bt) throw() {
+void check_fun(long predicate, const char *expr, const backtrace &bt) throw() {
     if (!predicate) {
         the_manager.kill();
         int e = errno;

--- a/backup/check.h
+++ b/backup/check.h
@@ -40,7 +40,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #include "backtrace.h"
 
-void check_fun(long predicate, const char *expr, const backtrace bt) throw();
+void check_fun(long predicate, const char *expr, const backtrace &bt) throw();
 
 // Like assert, except it doesn't go away under NDEBUG.
 // Do this with a function so that we don't get false answers on branch coverage.

--- a/backup/description.cc
+++ b/backup/description.cc
@@ -83,13 +83,13 @@ source_file * description::get_source_file(void) const throw()
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-void description::lock(const backtrace bt) throw() {
+void description::lock(const backtrace &bt) throw() {
     pmutex_lock(&m_mutex, BACKTRACE(&bt));
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-void description::unlock(const backtrace bt) throw() {
+void description::unlock(const backtrace &bt) throw() {
     pmutex_unlock(&m_mutex, BACKTRACE(&bt));
 }
 

--- a/backup/description.h
+++ b/backup/description.h
@@ -60,8 +60,8 @@ public:
     //  Return 0 on success, otherwise inform the backup manager of the error (fatal_error or backup_error) and return the error code.
     void set_source_file(source_file *file) throw();
     source_file * get_source_file(void) const throw();
-    void lock(const backtrace bt) throw();
-    void unlock(const backtrace bt) throw();
+    void lock(const backtrace &bt) throw();
+    void unlock(const backtrace &bt) throw();
 
     void lseek(off_t new_offset) throw();        
     void increment_offset(ssize_t nbyte) throw();

--- a/backup/fmap.cc
+++ b/backup/fmap.cc
@@ -86,7 +86,7 @@ fmap::~fmap() throw() {
 
 ////////////////////////////////////////////////////////////////////////////////
 // Description:  See fmap.h.
-void fmap::get(int fd, description** resultp, const backtrace bt) throw() {
+void fmap::get(int fd, description **resultp, const backtrace &bt) throw() {
     if (HotBackup::MAP_DBG) { 
         printf("get() called with fd = %d \n", fd);
     }
@@ -125,7 +125,7 @@ void fmap::put(int fd, description *file) throw() {
 //
 // Requires: the fd is something currently mapped.
 
-int fmap::erase(int fd, const backtrace bt) throw() {
+int fmap::erase(int fd, const backtrace &bt) throw() {
     with_fmap_locked ml(BACKTRACE(&bt));
     if ((size_t)fd  >= m_map.size()) {
         return 0;
@@ -177,11 +177,11 @@ void fmap::grow_array(int fd) throw() {
     }
 }
 
-void fmap::lock_fmap(const backtrace bt) throw() {
+void fmap::lock_fmap(const backtrace &bt) throw() {
     pmutex_lock(&get_put_mutex, BACKTRACE(&bt));
 }
 
-void fmap::unlock_fmap(const backtrace bt) throw() {
+void fmap::unlock_fmap(const backtrace &bt) throw() {
     pmutex_unlock(&get_put_mutex, BACKTRACE(&bt));
 }
 

--- a/backup/fmap.h
+++ b/backup/fmap.h
@@ -53,7 +53,7 @@ public:
     fmap() throw();
     ~fmap() throw();
 
-    void get(int fd, description**result, const backtrace bt) throw();
+    void get(int fd, description **result, const backtrace &bt) throw();
     // Effect:   Returns pointer (in *result) to the file description object that matches the
     //   given file descriptor.  This will return NULL if the given file
     //   descriptor has not been added to this map.
@@ -63,15 +63,15 @@ public:
     // Effect: adds given description pointer to array (acquires a lock)
 
     description* get_unlocked(int fd) throw(); // use this one instead of get() when you already have the lock.
-    int erase(int fd, const backtrace bt) throw() __attribute__((warn_unused_result)); // returns 0 or an error number.
+    int erase(int fd, const backtrace &bt) throw() __attribute__((warn_unused_result)); // returns 0 or an error number.
     int size(void) throw();
 private:
     void grow_array(int fd) throw();
     
     // Global locks used when the file descriptor map is updated.   Sometimes the backup system needs to hold the lock for several operations.
     // No errors are countenanced.
-    static void lock_fmap(backtrace bt) throw();
-    static void unlock_fmap(backtrace bt) throw();
+    static void lock_fmap(const backtrace &bt) throw();
+    static void unlock_fmap(const backtrace &bt) throw();
     friend class with_fmap_locked;
 
     friend class fmap_unit_test;
@@ -83,7 +83,7 @@ class with_fmap_locked {
   private:
     const backtrace m_bt;
   public:
-    with_fmap_locked(backtrace bt): m_bt(bt) {
+    with_fmap_locked(const backtrace &bt): m_bt(bt) {
         fmap::lock_fmap(m_bt);
     }
     ~with_fmap_locked(void) {

--- a/backup/manager.cc
+++ b/backup/manager.cc
@@ -244,7 +244,7 @@ error_out:
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-int manager::prepare_directories_for_backup(backup_session *session, backtrace bt) throw() {
+int manager::prepare_directories_for_backup(backup_session *session, const backtrace &bt) throw() {
     int r = 0;
     // Loop through all the current file descriptions and prepare them
     // for backup.

--- a/backup/manager.h
+++ b/backup/manager.h
@@ -135,7 +135,7 @@ private:
     void capture_rename(const char *, const char *);
     bool try_to_enter_session_and_lock(void) throw();
     void exit_session_and_unlock_or_die(void) throw();
-    int prepare_directories_for_backup(backup_session *session, const backtrace bt) throw();
+    int prepare_directories_for_backup(backup_session *session, const backtrace &bt) throw();
     void disable_descriptions(void) throw();
     void set_error_internal(int errnum, const char *format, va_list ap) throw();
     int setup_description_and_source_file(int fd, const char *file, const int flags) throw();

--- a/backup/mutex.cc
+++ b/backup/mutex.cc
@@ -42,7 +42,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "mutex.h"
 #include "check.h"
 
-void pmutex_lock(pthread_mutex_t *mutex, const backtrace bt) throw() {
+void pmutex_lock(pthread_mutex_t *mutex, const backtrace &bt) throw() {
     int r = pthread_mutex_lock(mutex);
     if (r != 0) {
         printf("HotBackup::pmutex_lock() failed, r = %d", r);
@@ -50,7 +50,7 @@ void pmutex_lock(pthread_mutex_t *mutex, const backtrace bt) throw() {
     check_bt(r==0, bt);
 }
 
-void pmutex_unlock(pthread_mutex_t *mutex, const backtrace bt) throw() {
+void pmutex_unlock(pthread_mutex_t *mutex, const backtrace &bt) throw() {
     int r = pthread_mutex_unlock(mutex);
     if (r != 0) {
         printf("HotBackup::pmutex_unlock() failed, r = %d", r);

--- a/backup/mutex.h
+++ b/backup/mutex.h
@@ -50,8 +50,8 @@ extern int pthread_mutex_unlock(pthread_mutex_t *) __attribute__((deprecated));
 extern void pmutex_lock(pthread_mutex_t *) throw();
 extern void pmutex_unlock(pthread_mutex_t *) throw();
 
-extern void pmutex_lock(pthread_mutex_t *, const backtrace) throw();
-extern void pmutex_unlock(pthread_mutex_t *, const backtrace) throw();
+extern void pmutex_lock(pthread_mutex_t *, const backtrace &) throw();
+extern void pmutex_unlock(pthread_mutex_t *, const backtrace &) throw();
 
 class with_mutex_locked {
   private:
@@ -62,7 +62,7 @@ class with_mutex_locked {
     with_mutex_locked(pthread_mutex_t *m): m_mutex(m), m_have_backtrace(false) {
         pmutex_lock(m_mutex);
     }
-    with_mutex_locked(pthread_mutex_t *m, const backtrace bt): m_mutex(m), m_have_backtrace(true), m_backtrace(bt) {
+    with_mutex_locked(pthread_mutex_t *m, const backtrace &bt): m_mutex(m), m_have_backtrace(true), m_backtrace(bt) {
         pmutex_lock(m_mutex, m_backtrace);
     }
     ~with_mutex_locked(void) {

--- a/backup/rwlock.cc
+++ b/backup/rwlock.cc
@@ -40,17 +40,17 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "mutex.h"
 #include "rwlock.h"
 
-void prwlock_rdlock(pthread_rwlock_t *lock, const backtrace bt) throw() {
+void prwlock_rdlock(pthread_rwlock_t *lock, const backtrace &bt) throw() {
     int r = pthread_rwlock_rdlock(lock);
     check_bt(r==0, bt);
 }
 
-void prwlock_wrlock(pthread_rwlock_t *lock, const backtrace bt) throw() {
+void prwlock_wrlock(pthread_rwlock_t *lock, const backtrace &bt) throw() {
     int r = pthread_rwlock_wrlock(lock);
     check_bt(r==0, bt);
 }
 
-void prwlock_unlock(pthread_rwlock_t *lock, const backtrace bt) throw() {
+void prwlock_unlock(pthread_rwlock_t *lock, const backtrace &bt) throw() {
     int r = pthread_rwlock_unlock(lock);
     check_bt(r==0, bt);
 }

--- a/backup/rwlock.h
+++ b/backup/rwlock.h
@@ -40,9 +40,9 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 extern void prwlock_rdlock(pthread_rwlock_t *) throw();
 extern void prwlock_wrlock(pthread_rwlock_t *) throw();
 extern void prwlock_unlock(pthread_rwlock_t *) throw();
-extern void prwlock_rdlock(pthread_rwlock_t *, const backtrace) throw();
-extern void prwlock_wrlock(pthread_rwlock_t *, const backtrace) throw();
-extern void prwlock_unlock(pthread_rwlock_t *, const backtrace) throw();
+extern void prwlock_rdlock(pthread_rwlock_t *, const backtrace &) throw();
+extern void prwlock_wrlock(pthread_rwlock_t *, const backtrace &) throw();
+extern void prwlock_unlock(pthread_rwlock_t *, const backtrace &) throw();
 
 class with_rwlock_rdlocked {
   private:
@@ -53,7 +53,7 @@ class with_rwlock_rdlocked {
     with_rwlock_rdlocked(pthread_rwlock_t *rw): m_rwlock(rw), m_have_backtrace(false) {
         prwlock_rdlock(m_rwlock);
     }
-    with_rwlock_rdlocked(pthread_rwlock_t *m, const backtrace bt): m_rwlock(m), m_have_backtrace(true), m_backtrace(bt) {
+    with_rwlock_rdlocked(pthread_rwlock_t *m, const backtrace &bt): m_rwlock(m), m_have_backtrace(true), m_backtrace(bt) {
         prwlock_rdlock(m_rwlock, m_backtrace);
     }
     ~with_rwlock_rdlocked(void) {
@@ -74,7 +74,7 @@ class with_rwlock_wrlocked {
     with_rwlock_wrlocked(pthread_rwlock_t *rw): m_rwlock(rw), m_have_backtrace(false) {
         prwlock_wrlock(m_rwlock);
     }
-    with_rwlock_wrlocked(pthread_rwlock_t *m, const backtrace bt): m_rwlock(m), m_have_backtrace(true), m_backtrace(bt) {
+    with_rwlock_wrlocked(pthread_rwlock_t *m, const backtrace &bt): m_rwlock(m), m_have_backtrace(true), m_backtrace(bt) {
         prwlock_wrlock(m_rwlock, m_backtrace);
     }
     ~with_rwlock_wrlocked(void) {


### PR DESCRIPTION
Modify methods to accept backtrace objects by reference;
add const modifiers where missing.