### PR TITLE
Add before and after stop capturing callbacks.

### DIFF
--- a/backup/backup.cc
+++ b/backup/backup.cc
@@ -325,10 +325,20 @@ int mkdir(const char *pathname, mode_t mode) {
     return r;
 }
 
-extern "C" int tokubackup_create_backup(const char *source_dirs[], const char *dest_dirs[], int dir_count,
-                                        backup_poll_fun_t poll_fun, void *poll_extra,
-                                        backup_error_fun_t error_fun, void *error_extra,
-                                        backup_exclude_copy_fun_t exclude_copy_fun, void *exclude_copy_extra) throw() {
+extern "C" int tokubackup_create_backup(const char *source_dirs[],
+                                        const char *dest_dirs[],
+                                        int dir_count,
+                                        backup_poll_fun_t poll_fun,
+                                        void *poll_extra,
+                                        backup_error_fun_t error_fun,
+                                        void *error_extra,
+                                        backup_exclude_copy_fun_t exclude_copy_fun,
+                                        void *exclude_copy_extra,
+                                        backup_before_stop_capt_fun_t bsc_fun,
+                                        void *bsc_extra,
+                                        backup_after_stop_capt_fun_t asc_fun,
+                                        void *asc_extra
+                                        ) throw() {
     for (int i=0; i<dir_count; i++) {
         if (source_dirs[i]==NULL) {
             error_fun(EINVAL, "One of the source directories is NULL", error_extra);
@@ -363,7 +373,17 @@ extern "C" int tokubackup_create_backup(const char *source_dirs[], const char *d
         }
     }
 
-    backup_callbacks calls(poll_fun, poll_extra, error_fun, error_extra, exclude_copy_fun, exclude_copy_extra, &get_throttle);
+    backup_callbacks calls(poll_fun,
+                           poll_extra,
+                           error_fun,
+                           error_extra,
+                           exclude_copy_fun,
+                           exclude_copy_extra,
+                           &get_throttle,
+                           bsc_fun,
+                           bsc_extra,
+                           asc_fun,
+                           asc_extra);
 
     // HUGE ASSUMPTION: - There is a 1:1 correspondence between source
     // and destination directories.

--- a/backup/backup.h
+++ b/backup/backup.h
@@ -50,10 +50,23 @@ typedef void (*backup_error_fun_t)(int error_number, const char *error_string, v
 // When it returns 0, the file is copied.  Otherwise, the file copy is skipped.
 typedef int (*backup_exclude_copy_fun_t)(const char *source_file,void *extra);
 
-int tokubackup_create_backup(const char *source_dirs[], const char *dest_dirs[], int dir_count,
-                             backup_poll_fun_t poll_fun, void *poll_extra,
-                             backup_error_fun_t error_fun, void *error_extra,
-                             backup_exclude_copy_fun_t check_fun, void *exclude_copy_extra)
+typedef void (*backup_before_stop_capt_fun_t)(void *extra);
+typedef void (*backup_after_stop_capt_fun_t)(void *extra);
+
+
+int tokubackup_create_backup(const char *source_dirs[],
+                             const char *dest_dirs[],
+                             int dir_count,
+                             backup_poll_fun_t poll_fun,
+                             void *poll_extra,
+                             backup_error_fun_t error_fun,
+                             void *error_extra,
+                             backup_exclude_copy_fun_t check_fun,
+                             void *exclude_copy_extra,
+                             backup_before_stop_capt_fun_t bsc_fun,
+                             void *bsc_extra,
+                             backup_after_stop_capt_fun_t asc_fun,
+                             void *asc_extra)
     throw() __attribute__((visibility("default")));
 // Effect: Backup the directories in source_dirs into correspnding dest_dirs.
 // Periodically call poll_fun.

--- a/backup/backup_callbacks.cc
+++ b/backup/backup_callbacks.cc
@@ -38,20 +38,29 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 //////////////////////////////////////////////////////////////////////////////
 //
-backup_callbacks::backup_callbacks(backup_poll_fun_t poll_fun, 
-                                   void *poll_extra, 
-                                   backup_error_fun_t error_fun, 
+backup_callbacks::backup_callbacks(backup_poll_fun_t poll_fun,
+                                   void *poll_extra,
+                                   backup_error_fun_t error_fun,
                                    void *error_extra,
                                    backup_exclude_copy_fun_t exclude_copy_fun,
                                    void *exclude_copy_extra,
-                                   backup_throttle_fun_t throttle_fun) throw()
-: m_poll_function(poll_fun), 
-m_poll_extra(poll_extra), 
-m_error_function(error_fun), 
+                                   backup_throttle_fun_t throttle_fun,
+                                   backup_before_stop_capt_fun_t bsc_fun,
+                                   void *bsc_extra,
+                                   backup_after_stop_capt_fun_t asc_fun,
+                                   void *asc_extra
+) throw()
+: m_poll_function(poll_fun),
+m_poll_extra(poll_extra),
+m_error_function(error_fun),
 m_error_extra(error_extra),
 m_exclude_copy_function(exclude_copy_fun),
 m_exclude_copy_extra(exclude_copy_extra),
-m_throttle_function(throttle_fun)
+m_throttle_function(throttle_fun),
+m_bsc_fun(bsc_fun),
+m_bsc_extra(bsc_extra),
+m_asc_fun(asc_fun),
+m_asc_extra(asc_extra)
 {}
 
 //////////////////////////////////////////////////////////////////////////////
@@ -80,4 +89,3 @@ int backup_callbacks::exclude_copy(const char *source) throw() {
         r = m_exclude_copy_function(source, m_exclude_copy_extra);
     return r;
 }
-

--- a/backup/backup_callbacks.h
+++ b/backup/backup_callbacks.h
@@ -47,17 +47,29 @@ typedef unsigned long (*backup_throttle_fun_t)(void);
 class backup_callbacks
 {
 public:
-    backup_callbacks(backup_poll_fun_t poll_fun, 
-                     void *poll_extra, 
-                     backup_error_fun_t error_fun, 
+    backup_callbacks(backup_poll_fun_t poll_fun,
+                     void *poll_extra,
+                     backup_error_fun_t error_fun,
                      void *error_extra,
                      backup_exclude_copy_fun_t exclude_copy_fun,
                      void *exclude_copy_extra,
-                     backup_throttle_fun_t throttle_fun) throw();
+                     backup_throttle_fun_t throttle_fun,
+                     backup_before_stop_capt_fun_t bsc_fun,
+                     void *bsc_extra,
+                     backup_after_stop_capt_fun_t asc_fun,
+                     void *asc_extra) throw();
     int poll(float progress, const char *progress_string) throw();
     void report_error(int error_number, const char *error_description) throw();
     unsigned long get_throttle(void) throw();
     int exclude_copy(const char *source) throw();
+    void before_stop_capt_call() throw() {
+        if (m_bsc_fun)
+            m_bsc_fun(m_bsc_extra);
+    }
+    void after_stop_capt_call() throw() {
+        if (m_asc_fun)
+            m_asc_fun(m_asc_extra);
+    }
 private:
     backup_callbacks() throw() {};
     backup_poll_fun_t m_poll_function;
@@ -67,6 +79,10 @@ private:
     backup_exclude_copy_fun_t m_exclude_copy_function;
     void *m_exclude_copy_extra;
     backup_throttle_fun_t m_throttle_function;
+    backup_before_stop_capt_fun_t m_bsc_fun;
+    void *m_bsc_extra;
+    backup_after_stop_capt_fun_t m_asc_fun;
+    void *m_asc_extra;
 };
 
 #endif // end of header guardian.

--- a/backup/manager.cc
+++ b/backup/manager.cc
@@ -212,6 +212,7 @@ disable_out: // preserves r if r!=0
         while (m_keep_capturing) sched_yield();
             }) );
 
+    calls->before_stop_capt_call();
     {
         with_rwlock_wrlocked ms(&m_session_rwlock, BACKTRACE(NULL));
 
@@ -226,6 +227,7 @@ disable_out: // preserves r if r!=0
         delete m_session;
         m_session = NULL;
     }
+    calls->after_stop_capt_call();
 
 unlock_out: // preserves r if r!0
 


### PR DESCRIPTION
The callbacks are used for storing binlog position.

See also:
https://github.com/percona/percona-server/pull/1324
https://github.com/percona/percona-server/pull/1325