### PR TITLE
Fix yakkety build issue which leads to unresolved symbols on link.

### DIFF
--- a/backup/CMakeLists.txt
+++ b/backup/CMakeLists.txt
@@ -1,6 +1,14 @@
 cmake_minimum_required(VERSION 2.8.8)
 project(HotBackup)
 
+# pick language dialect
+check_cxx_compiler_flag(-std=c++03 HAVE_STDCXX03)
+if (HAVE_STDCXX03)
+  set(CMAKE_CXX_FLAGS "-std=c++03 -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS}")
+else ()
+  message(FATAL_ERROR "${CMAKE_CXX_COMPILER} doesn't support -std=c++03, you need one that does.")
+endif ()
+
 # No implicit templates, since that's how mysql compiles.
 if (NOT CMAKE_CXX_COMPILER_ID MATCHES Clang)
   set(CMAKE_CXX_FLAGS "-fno-implicit-templates  ${CMAKE_CXX_FLAGS}")


### PR DESCRIPTION
The full bug description can be found here:
https://bugs.launchpad.net/percona-server/+bug/1654501

http://jenkins.percona.com/view/5.7/job/mysql-5.7-param/639/
http://jenkins.percona.com/view/PS%205.6/job/percona-server-5.6-param/1621/