### PR TITLE
The backup tests no longer compile. After getting them to compile, we found a memory leak in the backup software.  In addition several bugs were found by the thread sanitizer.

### DIFF
--- a/backup/CMakeLists.txt
+++ b/backup/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.8)
 project(HotBackup)
 
 # pick language dialect
+include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag(-std=c++03 HAVE_STDCXX03)
 if (HAVE_STDCXX03)
   set(CMAKE_CXX_FLAGS "-std=c++03 -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS}")

--- a/backup/CMakeLists.txt
+++ b/backup/CMakeLists.txt
@@ -3,12 +3,17 @@ project(HotBackup)
 
 # pick language dialect
 include(CheckCXXCompilerFlag)
-check_cxx_compiler_flag(-std=c++03 HAVE_STDCXX03)
-if (HAVE_STDCXX03)
-  set(CMAKE_CXX_FLAGS "-std=c++03 -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS}")
+check_cxx_compiler_flag(-std=c++11 HAVE_STDCXX11)
+if (HAVE_STDCXX11)
+  set(CMAKE_CXX_FLAGS "-std=c++11 -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS}")
 else ()
-  message(FATAL_ERROR "${CMAKE_CXX_COMPILER} doesn't support -std=c++03, you need one that does.")
-endif ()
+  check_cxx_compiler_flag(-std=c++03 HAVE_STDCXX03)
+  if (HAVE_STDCXX03)
+    set(CMAKE_CXX_FLAGS "-std=c++03 -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS}")
+  else ()
+    message(FATAL_ERROR "${CMAKE_CXX_COMPILER} doesn't support -std=c++03, you need one that does.")
+  endif ()
+endif()
 
 # No implicit templates, since that's how mysql compiles.
 if (NOT CMAKE_CXX_COMPILER_ID MATCHES Clang)

--- a/backup/backup.h
+++ b/backup/backup.h
@@ -63,10 +63,10 @@ int tokubackup_create_backup(const char *source_dirs[],
                              void *error_extra,
                              backup_exclude_copy_fun_t check_fun,
                              void *exclude_copy_extra,
-                             backup_before_stop_capt_fun_t bsc_fun,
-                             void *bsc_extra,
-                             backup_after_stop_capt_fun_t asc_fun,
-                             void *asc_extra)
+                             backup_before_stop_capt_fun_t bsc_fun = 0,
+                             void *bsc_extra = 0,
+                             backup_after_stop_capt_fun_t asc_fun = 0,
+                             void *asc_extra = 0)
     throw() __attribute__((visibility("default")));
 // Effect: Backup the directories in source_dirs into correspnding dest_dirs.
 // Periodically call poll_fun.

--- a/backup/backup_callbacks.h
+++ b/backup/backup_callbacks.h
@@ -54,10 +54,10 @@ public:
                      backup_exclude_copy_fun_t exclude_copy_fun,
                      void *exclude_copy_extra,
                      backup_throttle_fun_t throttle_fun,
-                     backup_before_stop_capt_fun_t bsc_fun,
-                     void *bsc_extra,
-                     backup_after_stop_capt_fun_t asc_fun,
-                     void *asc_extra) throw();
+                     backup_before_stop_capt_fun_t bsc_fun = 0,
+                     void *bsc_extra = 0,
+                     backup_after_stop_capt_fun_t asc_fun = 0,
+                     void *asc_extra = 0) throw();
     int poll(float progress, const char *progress_string) throw();
     void report_error(int error_number, const char *error_description) throw();
     unsigned long get_throttle(void) throw();

--- a/backup/backup_debug.cc
+++ b/backup/backup_debug.cc
@@ -37,6 +37,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_debug.h"
 #include "backup_helgrind.h"
 #include <stdio.h>
+#include <atomic>
 
 namespace HotBackup {
 
@@ -117,7 +118,7 @@ void InterposeError(const char *s, const char *arg) throw() {
     }
 }
 
-static int PAUSE_POINTS = 0x00;
+static std::atomic_int PAUSE_POINTS = {0};
 
 bool should_pause(int flag) throw() {
     bool result = false;
@@ -155,7 +156,7 @@ bool should_pause(int flag) throw() {
 
 void toggle_pause_point(int flag) throw() {
     TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(&PAUSE_POINTS, sizeof(PAUSE_POINTS));
-    PAUSE_POINTS = PAUSE_POINTS ^ flag;
+    PAUSE_POINTS ^= flag;
 }
 
 } // End of namespace.

--- a/backup/copier.cc
+++ b/backup/copier.cc
@@ -150,7 +150,7 @@ int copier::do_copy(void) throw() {
         
         {
             with_mutex_locked tm(&m_todo_mutex, BACKTRACE(NULL));
-            fname = m_todo.back();
+            fname = m_todo.front();
         }
         TRACE("Copying: ", fname);
         
@@ -166,7 +166,7 @@ int copier::do_copy(void) throw() {
 
         {
             with_mutex_locked tm(&m_todo_mutex, BACKTRACE(NULL));
-            m_todo.pop_back();
+            m_todo.pop_front();
         }
         
         r = this->copy_stripped_file(fname);

--- a/backup/copier.h
+++ b/backup/copier.h
@@ -43,7 +43,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #include <stdint.h>
 #include <sys/types.h>
-#include <vector>
+#include <deque>
 #include <dirent.h>
 #include <pthread.h>
 
@@ -93,7 +93,7 @@ class copier {
   private:
     const char *m_source;
     const char *m_dest;
-    std::vector<char *> m_todo;
+    std::deque<char *> m_todo;
     backup_callbacks *m_calls;
     file_hash_table * const m_table;
     size_t m_total_written_this_file;

--- a/backup/manager.h
+++ b/backup/manager.h
@@ -62,7 +62,6 @@ private:
     volatile bool m_done_copying;   // Backup manager sets this true when copying is done.  Happens after m_is_captring
 #endif
 
-    volatile bool m_is_dead; // true if some error occured so that the backup system shouldn't try any more.
     volatile bool m_backup_is_running; // true if the backup is running.  This can be accessed without any locks.
 
     fmap m_map;

--- a/backup/manager.h
+++ b/backup/manager.h
@@ -49,17 +49,18 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include <stdarg.h>
 #include <sys/types.h>
 #include <vector>
+#include <atomic>
 
 class manager : public manager_state
 {
 private:
 
 #ifdef GLASSBOX
-    volatile bool m_pause_disable;
-    volatile bool m_start_copying; // For test purposes, we can arrange to initialize the backup but not actually start copying.
-    volatile bool m_keep_capturing; // For test purposes, we can arrange to keep capturing the backup until the client tells us to stop.
-    volatile bool m_is_capturing;   // Backup manager sets to true when capturing is running, sets to false when capturing has stopped.   We look at m_start_copying after setting m_is_capturing=true.
-    volatile bool m_done_copying;   // Backup manager sets this true when copying is done.  Happens after m_is_captring
+    std::atomic_bool m_pause_disable;
+    std::atomic_bool m_start_copying; // For test purposes, we can arrange to initialize the backup but not actually start copying.
+    std::atomic_bool m_keep_capturing; // For test purposes, we can arrange to keep capturing the backup until the client tells us to stop.
+    std::atomic_bool m_is_capturing;   // Backup manager sets to true when capturing is running, sets to false when capturing has stopped.   We look at m_start_copying after setting m_is_capturing=true.
+    std::atomic_bool m_done_copying;   // Backup manager sets this true when copying is done.  Happens after m_is_captring
 #endif
 
     volatile bool m_backup_is_running; // true if the backup is running.  This can be accessed without any locks.
@@ -74,7 +75,7 @@ private:
     backup_session *m_session;
     static pthread_rwlock_t m_session_rwlock;
 
-    volatile unsigned long m_throttle;
+    std::atomic_ulong m_throttle;
 
     // Error handling.
     static pthread_mutex_t m_error_mutex;     // When testing errors grab this mutex. 

--- a/backup/manager_state.h
+++ b/backup/manager_state.h
@@ -38,6 +38,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #ident "$Id$"
 
 #include <pthread.h>
+#include <atomic>
 
 class manager_state {
 public:
@@ -53,9 +54,9 @@ protected:
     void enable_copy(void) throw();
     void disable_copy(void) throw();
 private:
-    volatile bool m_is_dead;
-    volatile bool m_capture_enabled;
-    volatile bool m_copy_enabled;
+    std::atomic_bool m_is_dead;
+    std::atomic_bool m_capture_enabled;
+    std::atomic_bool m_copy_enabled;
 };
 
 #endif // End of header guardian.

--- a/backup/source_file.cc
+++ b/backup/source_file.cc
@@ -104,6 +104,10 @@ source_file::~source_file(void) throw() {
             check(r==0);
         }
     }
+    if (m_destination_file != NULL) {
+        delete m_destination_file;
+        m_destination_file = NULL;
+    }
 }
 
 ////////////////////////////////////////////////////////

--- a/backup/source_file.cc
+++ b/backup/source_file.cc
@@ -220,7 +220,7 @@ int source_file::rename(const char * new_name) throw() {
 ////////////////////////////////////////////////////////
 //
 void source_file::add_reference(void) throw() {
-    __sync_fetch_and_add(&m_reference_count, 1);
+    m_reference_count.fetch_add(1);
 }
 
 ////////////////////////////////////////////////////////
@@ -228,7 +228,7 @@ void source_file::add_reference(void) throw() {
 void source_file::remove_reference(void) throw() {
     // TODO.  How can the code that decremented a reference count only if it was positive be right?  Under what conditions could someone be decrementing a refcount when they don't know that it's positive?
     check(m_reference_count>0);
-    __sync_fetch_and_add(&m_reference_count, -1);
+    m_reference_count.fetch_add(-1);
 }
 
 ////////////////////////////////////////////////////////

--- a/backup/source_file.h
+++ b/backup/source_file.h
@@ -38,7 +38,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #define SOURCE_FILE_H
 
 #include <stdint.h>
-
+#include <atomic>
 #include "destination_file.h"
 #include "description.h"
 
@@ -104,7 +104,7 @@ private:
     char * m_full_path; // the source_file owns this.
     source_file *m_next;
     pthread_rwlock_t m_name_rwlock;
-    unsigned int m_reference_count;
+    std::atomic_uint m_reference_count;
 
     pthread_mutex_t  m_mutex;
     pthread_cond_t   m_cond;

--- a/backup/tests/backup_test_helpers.cc
+++ b/backup/tests/backup_test_helpers.cc
@@ -150,7 +150,7 @@ struct backup_thread_extra_t {
     int                expect_return_result;
 };
 
-static volatile bool backup_is_done = false;
+static std::atomic_bool backup_is_done = {false};
 
 static void* start_backup_thread_fun(void *backup_extra_v) {
     backup_thread_extra_t *backup_extra = (backup_thread_extra_t*)backup_extra_v;

--- a/backup/tests/backup_test_helpers.h
+++ b/backup/tests/backup_test_helpers.h
@@ -41,6 +41,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_internal.h"
 #include <pthread.h>
 #include <time.h>
+#include <atomic>
 
 int systemf(const char formatstring, ...); // Effect: run system on the snprintf of the format string and args.
 

--- a/backup/tests/create_rename_race.cc
+++ b/backup/tests/create_rename_race.cc
@@ -42,7 +42,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_test_helpers.h"
 #include "backup_debug.h"
 
-const int N=10;
 const int N_FNAMES = 2;
 
 void* do_backups(void *v) {

--- a/backup/tests/create_unlink_race.cc
+++ b/backup/tests/create_unlink_race.cc
@@ -42,7 +42,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_test_helpers.h"
 #include "backup_debug.h"
 
-const int N=10;
 const int N_FNAMES = 1;
 
 void* do_backups(void *v) {

--- a/backup/tests/ftruncate_injection_6480.cc
+++ b/backup/tests/ftruncate_injection_6480.cc
@@ -48,8 +48,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_test_helpers.h"
 #include "real_syscalls.h"
 
-static const int ERRORS_TO_CHECK = 1;
-
 static int iteration = 0;
 
 const int ERROR = EIO;

--- a/backup/tests/open_injection_6476.cc
+++ b/backup/tests/open_injection_6476.cc
@@ -48,8 +48,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_test_helpers.h"
 #include "real_syscalls.h"
 
-static const int ERRORS_TO_CHECK = 1;
-
 static volatile int iteration = 0;
 
 static open_fun_t original_open;

--- a/backup/tests/open_prepare_race_6610.cc
+++ b/backup/tests/open_prepare_race_6610.cc
@@ -43,7 +43,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 static char *src;
 
-static volatile int n_backups_done = 0;
+static std::atomic_int n_backups_done = {0};
 static const int n_backups_to_do = 4;
 
 static void* open_close_loop(void * ignore) {
@@ -72,7 +72,7 @@ int test_main(int argc, const char *argv[] __attribute__((__unused__))) {
         setup_destination();
         start_backup_thread(&bth);
         finish_backup_thread(bth);
-        __sync_fetch_and_add(&n_backups_done, 1);
+        n_backups_done.fetch_add(1);
     }
     {
         void *result;

--- a/backup/tests/open_write_close.cc
+++ b/backup/tests/open_write_close.cc
@@ -42,7 +42,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include <unistd.h>
 #include <string.h>
 #include "backup_helgrind.h"
-
 #include "backup.h"
 #include "backup_test_helpers.h"
 
@@ -63,7 +62,7 @@ static int verify(void)
     return r;
 }
 
-volatile int write_done = 0;
+std::atomic_int write_done = {0};
 
 static int write_poll(float progress, const char *progress_string, void *extra) {
     check(0<=progress && progress<1);

--- a/backup/tests/open_write_race.cc
+++ b/backup/tests/open_write_race.cc
@@ -40,7 +40,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #include "backup_test_helpers.h"
 
-volatile long counter = 2; // so we know that all the work is done.
+std::atomic_long counter = {2}; // so we know that all the work is done.
 
 char *src; 
 
@@ -69,7 +69,7 @@ void* do_writes(void *v) {
         wcount++;
         printf(".");
     }
-    __sync_fetch_and_add(&counter, -1); // let do_backups know we finished.
+    counter.fetch_add(-1); // let do_backups know we finished.
     return v;
 }    
 
@@ -87,7 +87,7 @@ void* do_opens(void *v) {
         int r = close(fds[i]);
         check(r==0);
     }
-    __sync_fetch_and_add(&counter, -1); // done doing the opens
+    counter.fetch_add(-1); // done doing the opens
     return v;
 }
 

--- a/backup/tests/range_locks.cc
+++ b/backup/tests/range_locks.cc
@@ -54,7 +54,8 @@ static void* doit(void* ignore) {
 
 
     stepb = 1;
-    while (!stepc);
+    while (!stepc)
+      ;
     { int r = sf.unlock_range(doit_lo, doit_hi); check(r==0); }
 
     return ignore;

--- a/backup/tests/range_locks.cc
+++ b/backup/tests/range_locks.cc
@@ -42,9 +42,9 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 class source_file sf("hello");
 
-volatile int stepa = 0;
-volatile int stepb = 0;
-volatile int stepc = 0;
+std::atomic_int stepa = {0};
+std::atomic_int stepb = {0};
+std::atomic_int stepc = {0};
 
 static const uint64_t doit_lo = 5, doit_hi = 10;
 static void* doit(void* ignore) {

--- a/backup/tests/realpath_error_injection.cc
+++ b/backup/tests/realpath_error_injection.cc
@@ -108,7 +108,7 @@ void call_unlink(const char * const file)
 }
 
 static realpath_fun_t original_realpath = NULL;
-volatile static bool inject_realpath_error = false;
+static std::atomic_bool inject_realpath_error = {false};
 char *my_realpath(const char *path, char *result) {
     if (inject_realpath_error) {
         errno = realpath_error_to_inject;

--- a/backup/tests/rename_injection.cc
+++ b/backup/tests/rename_injection.cc
@@ -48,8 +48,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_test_helpers.h"
 #include "real_syscalls.h"
 
-static const int ERRORS_TO_CHECK = 1;
-
 static volatile int iteration = 0;
 
 static rename_fun_t original_rename;

--- a/backup/tests/two_renames_race.cc
+++ b/backup/tests/two_renames_race.cc
@@ -43,7 +43,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_test_helpers.h"
 #include "backup_debug.h"
 
-const int N=10;
 const int N_FNAMES = 2;
 
 void* do_backups(void *v) {

--- a/backup/tests/unlink_injection.cc
+++ b/backup/tests/unlink_injection.cc
@@ -48,8 +48,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_test_helpers.h"
 #include "real_syscalls.h"
 
-static const int ERRORS_TO_CHECK = 1;
-
 static volatile int iteration = 0;
 
 static unlink_fun_t original_unlink;


### PR DESCRIPTION
The backup tests no longer compile. After getting them to compile, we found a memory leak in the backup software.  In addition several bugs were found by the thread sanitizer.  Here is a summary:
1. Fix the compilation of the tests.
2. Fix a memory leak detected with valgrind (and the address sanitizer).
3. Fix a memory use after free bug in the backup copier detected with the thread sanitizer.  This bug can result in a broken backup.
4. Fix data races detected with the thread sanitizer in the tests and in the backup software by using atomic variables.

Tools:
Ubuntu 17.10
Clang 4.0.1
Cmake 3.9.1

Directions:
CXXFLAGS=-fsanitize=thread CC=clang CXX=clang++ cmake -D CMAKE_BUILD_TYPE=Debug ..
make
ctest

Copyright (c) 2017, Rik Prohaska
All rights reserved.

Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.