### PR TITLE
lp1738417: Fixing a clang 5 build error

### DIFF
--- a/backup/backup.cc
+++ b/backup/backup.cc
@@ -36,7 +36,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #include <stdio.h> // rename(),
 #include <fcntl.h> // open()
-#include <unistd.h> // close(), write(), read(), unlink(), truncate(), etc.
 #include <sys/stat.h> // mkdir()
 #include <errno.h>
 #include <dlfcn.h>


### PR DESCRIPTION
read, and some other functions are defined at multiple locations:
* in unistd.h
* in backup.cc

This causes a build error with clang5 and RelWithDebInfo. For some
reason, other build variants/compiler are unaffected, but as the
file in question didn't require anything from unistd, it can be
removed.