### PR TITLE
Prepare for PS-3933 (Make Percona Server code compatible with C++11)

### DIFF
--- a/backup/CMakeLists.txt
+++ b/backup/CMakeLists.txt
@@ -1,19 +1,6 @@
 cmake_minimum_required(VERSION 2.8.8)
 project(HotBackup)
 
-# pick language dialect
-check_cxx_compiler_flag(-std=c++03 HAVE_STDCXX03)
-if (HAVE_STDCXX03)
-  set(CMAKE_CXX_FLAGS "-std=c++03 -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS}")
-else ()
-  message(FATAL_ERROR "${CMAKE_CXX_COMPILER} doesn't support -std=c++03, you need one that does.")
-endif ()
-
-# No implicit templates, since that's how mysql compiles.
-if (NOT CMAKE_CXX_COMPILER_ID MATCHES Clang)
-  set(CMAKE_CXX_FLAGS "-fno-implicit-templates  ${CMAKE_CXX_FLAGS}")
-endif ()
-
 set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS 
   _FILE_OFFSET_BITS=64 
   _LARGEFILE64_SOURCE)

--- a/backup/copier.cc
+++ b/backup/copier.cc
@@ -56,8 +56,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include <unistd.h>
 #include <vector>
 
-template class std::vector<char *>;
-
 #if DEBUG_HOTBACKUP
 #define WARN(string, arg) HotBackup::CopyWarn(string, arg)
 #define TRACE(string, arg) HotBackup::CopyTrace(string, arg)

--- a/backup/fmap.cc
+++ b/backup/fmap.cc
@@ -48,7 +48,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include <vector>
 
 class file_description;
-template class std::vector<file_description *>;
 
 // This mutx protects the file descriptor map
 static pthread_mutex_t get_put_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -184,6 +183,3 @@ void fmap::lock_fmap(const backtrace bt) throw() {
 void fmap::unlock_fmap(const backtrace bt) throw() {
     pmutex_unlock(&get_put_mutex, BACKTRACE(&bt));
 }
-
-// Instantiate the templates we need
-template class std::vector<description*>;

--- a/backup/source_file.cc
+++ b/backup/source_file.cc
@@ -341,6 +341,3 @@ void source_file::fd_unlock(void) throw()
 {
     pmutex_unlock(&m_fd_mutex);
 }
-
-// Instantiate the templates we need
-template class std::vector<range>;

--- a/backup/tests/open_close_6731.cc
+++ b/backup/tests/open_close_6731.cc
@@ -175,5 +175,3 @@ int test_main(int argc __attribute__((__unused__)), const char *argv[] __attribu
     }
     return 0;
 }
-
-template class std::vector<int>;

--- a/backup/tests/test6469_many_enospc_injection.cc
+++ b/backup/tests/test6469_many_enospc_injection.cc
@@ -162,7 +162,3 @@ int test_main(int argc __attribute__((__unused__)), const char *argv[] __attribu
     free(src);
     return 0;
 }
-
-// Instantiate what we need
-template class std::vector<int>;
-template class std::vector<long>;

--- a/backup/tests/test6477_close_injection.cc
+++ b/backup/tests/test6477_close_injection.cc
@@ -152,7 +152,3 @@ int test_main(int argc __attribute__((__unused__)), const char *argv[] __attribu
     free(src);
     return 0;
 }
-
-// Instantiate what we need
-template class std::vector<int>;
-template class std::vector<long>;

--- a/backup/tests/test6483_mkdir_injection.cc
+++ b/backup/tests/test6483_mkdir_injection.cc
@@ -157,6 +157,3 @@ int test_main(int argc __attribute__((__unused__)), const char *argv[] __attribu
     free(realdst);
     return 0;
 }
-
-// Instantiate what we need
-template class std::vector<long>;


### PR DESCRIPTION
https://jira.percona.com/browse/PS-3933

Reimplemented fix for PS-1045
"LP #1654501: libHotBackup.so fails to load on Ubuntu Yakkety 64-bit, debug build"
(https://jira.percona.com/browse/PS-1045).
Instead of manually specifying '-std=c++03' for 'CMAKE_CXX_FLAGS' we now
eliminate the primary source of the problem with unresolved symbol -
'-fno-implicit-templates' flag passed to the compiler.
This commit also eliminates all explicit class template instantiations from
the source code.

This step is required to make sure that '-std=xxx' option is set only once in
the Percona Server top-level 'CMakeLists.txt' (either explicitly via
'CMAKE_CXX_FLAGS' or implicitly via 'CMAKE_CXX_STANDARD' in newer versions of
'CMake') and is never changed by submodules. This will help to make sure that
c++11 options will be propagated properly throughout the project source code
and are never rewritten.