### PR TITLE
PS-4747 : 8.0 : Port TokuDB Hot Backup plugin to 8.0

### DIFF
--- a/backup/CMakeLists.txt
+++ b/backup/CMakeLists.txt
@@ -2,16 +2,11 @@ cmake_minimum_required(VERSION 2.8.8)
 project(HotBackup)
 
 # pick language dialect
-check_cxx_compiler_flag(-std=c++03 HAVE_STDCXX03)
-if (HAVE_STDCXX03)
-  set(CMAKE_CXX_FLAGS "-std=c++03 -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS}")
+check_cxx_compiler_flag(-std=c++11 HAVE_STDCXX03)
+if (HAVE_STDCXX11)
+  set(CMAKE_CXX_FLAGS "-std=c++11 -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS}")
 else ()
-  message(FATAL_ERROR "${CMAKE_CXX_COMPILER} doesn't support -std=c++03, you need one that does.")
-endif ()
-
-# No implicit templates, since that's how mysql compiles.
-if (NOT CMAKE_CXX_COMPILER_ID MATCHES Clang)
-  set(CMAKE_CXX_FLAGS "-fno-implicit-templates  ${CMAKE_CXX_FLAGS}")
+  message(FATAL_ERROR "${CMAKE_CXX_COMPILER} doesn't support -std=c++11, you need one that does.")
 endif ()
 
 set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS 

--- a/backup/fmap.cc
+++ b/backup/fmap.cc
@@ -47,9 +47,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include <string.h>
 #include <vector>
 
-class file_description;
-template class std::vector<file_description *>;
-
 // This mutx protects the file descriptor map
 static pthread_mutex_t get_put_mutex = PTHREAD_MUTEX_INITIALIZER;
 
@@ -72,7 +69,7 @@ fmap::fmap() throw() {}
 //     Destructor.
 //
 fmap::~fmap() throw() {
-    for(std::vector<file_description *>::size_type i = 0; i < m_map.size(); ++i)
+    for(std::vector<description *>::size_type i = 0; i < m_map.size(); ++i)
     {
         description *file = m_map[i];
         if (file == NULL) {
@@ -186,4 +183,4 @@ void fmap::unlock_fmap(const backtrace bt) throw() {
 }
 
 // Instantiate the templates we need
-template class std::vector<description*>;
+template class std::vector<description *>;

--- a/backup/fmap.h
+++ b/backup/fmap.h
@@ -45,6 +45,8 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 class backup_directory;
 
+extern template class std::vector<description *>;
+
 class fmap
 {
 private:


### PR DESCRIPTION
- Fixed linkage and removed -fno-implicit-templates and some internal template
  issues that caused missing symbols in library.