### PR TITLE
PS-5102: MySQL 8.0.16 errors

### DIFF
--- a/backup/CMakeLists.txt
+++ b/backup/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 2.8.8)
+
+if (POLICY CMP0048)
+  cmake_policy(SET CMP0048 NEW)
+endif (POLICY CMP0048)
+
 project(HotBackup)
+
 
 # pick language dialect
 check_cxx_compiler_flag(-std=c++11 HAVE_STDCXX11)


### PR DESCRIPTION
Tokudb backup reports a CMP0048 policy warning.

This is silenced by setting the behavior to new if using CMake 3.0 or newer.