### PR TITLE
PS-6945 : tokubackup is broken since it no longer exports the correct large file API

### DIFF
--- a/backup/CMakeLists.txt
+++ b/backup/CMakeLists.txt
@@ -8,6 +8,7 @@ project(HotBackup)
 
 
 # pick language dialect
+include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag(-std=c++11 HAVE_STDCXX11)
 if (HAVE_STDCXX11)
   set(CMAKE_CXX_FLAGS "-std=c++11 -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS}")

--- a/backup/backup.cc
+++ b/backup/backup.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #include <stdio.h> // rename(),
 #include <fcntl.h> // open()
+#include <unistd.h> // close(), write(), read(), unlink(), truncate(), etc.
 #include <sys/stat.h> // mkdir()
 #include <errno.h>
 #include <dlfcn.h>

--- a/backup/backup.h
+++ b/backup/backup.h
@@ -63,10 +63,10 @@ int tokubackup_create_backup(const char *source_dirs[],
                              void *error_extra,
                              backup_exclude_copy_fun_t check_fun,
                              void *exclude_copy_extra,
-                             backup_before_stop_capt_fun_t bsc_fun,
-                             void *bsc_extra,
-                             backup_after_stop_capt_fun_t asc_fun,
-                             void *asc_extra)
+                             backup_before_stop_capt_fun_t bsc_fun = nullptr,
+                             void *bsc_extra = nullptr,
+                             backup_after_stop_capt_fun_t asc_fun = nullptr,
+                             void *asc_extra = nullptr)
     throw() __attribute__((visibility("default")));
 // Effect: Backup the directories in source_dirs into correspnding dest_dirs.
 // Periodically call poll_fun.

--- a/backup/backup_callbacks.h
+++ b/backup/backup_callbacks.h
@@ -54,10 +54,10 @@ public:
                      backup_exclude_copy_fun_t exclude_copy_fun,
                      void *exclude_copy_extra,
                      backup_throttle_fun_t throttle_fun,
-                     backup_before_stop_capt_fun_t bsc_fun,
-                     void *bsc_extra,
-                     backup_after_stop_capt_fun_t asc_fun,
-                     void *asc_extra) throw();
+                     backup_before_stop_capt_fun_t bsc_fun = nullptr,
+                     void *bsc_extra = nullptr,
+                     backup_after_stop_capt_fun_t asc_fun = nullptr,
+                     void *asc_extra = nullptr) throw();
     int poll(float progress, const char *progress_string) throw();
     void report_error(int error_number, const char *error_description) throw();
     unsigned long get_throttle(void) throw();

--- a/backup/manager.h
+++ b/backup/manager.h
@@ -62,7 +62,6 @@ private:
     volatile bool m_done_copying;   // Backup manager sets this true when copying is done.  Happens after m_is_captring
 #endif
 
-    volatile bool m_is_dead; // true if some error occured so that the backup system shouldn't try any more.
     volatile bool m_backup_is_running; // true if the backup is running.  This can be accessed without any locks.
 
     fmap m_map;

--- a/backup/source_file.cc
+++ b/backup/source_file.cc
@@ -104,6 +104,11 @@ source_file::~source_file(void) throw() {
             check(r==0);
         }
     }
+
+    if (m_destination_file != NULL) {
+        delete m_destination_file;
+        m_destination_file = NULL;
+    }
 }
 
 ////////////////////////////////////////////////////////

--- a/backup/tests/CMakeLists.txt
+++ b/backup/tests/CMakeLists.txt
@@ -83,6 +83,9 @@ set(glassboxtests
   unlink_during_copy_test6515c
   unlink_injection
   write_race
+  lseek_write
+  open_lseek_write
+  pwrite_during_backup
   )
 
 set(glassboxtests_no_grind

--- a/backup/tests/abort_while_holding_lock.cc
+++ b/backup/tests/abort_while_holding_lock.cc
@@ -83,19 +83,19 @@ int test_main(int argc __attribute__((unused)), const char *argv[] __attribute__
     setup_source();
     char *src = get_src();
     size_t len = strlen(src)+100;
-    A = (char*)malloc(len); { int r = snprintf(A, len, "%s/A", src); assert(size_t(r)<len); }
-    B = (char*)malloc(len); { int r = snprintf(B, len, "%s/B", src); assert(size_t(r)<len); }
-    C = (char*)malloc(len); { int r = snprintf(A, len, "%s/C", src); assert(size_t(r)<len); }
-    D = (char*)malloc(len); { int r = snprintf(B, len, "%s/D", src); assert(size_t(r)<len); }
+    A = (char*)malloc(len); { int r = snprintf(A, len, "%s/A", src); check(size_t(r)<len); }
+    B = (char*)malloc(len); { int r = snprintf(B, len, "%s/B", src); check(size_t(r)<len); }
+    C = (char*)malloc(len); { int r = snprintf(A, len, "%s/C", src); check(size_t(r)<len); }
+    D = (char*)malloc(len); { int r = snprintf(B, len, "%s/D", src); check(size_t(r)<len); }
     {
         int fd = open(A, O_WRONLY | O_CREAT, 0777);
-        assert(fd>=0);
+        check(fd>=0);
         int r = close(fd);
-        assert(r==0);
+        check(r==0);
     }
     {
         int r = rename(A, B);
-        assert(r==0);
+        check(r==0);
     }
     cleanup_dirs();
     free(src);

--- a/backup/tests/create_rename_race.cc
+++ b/backup/tests/create_rename_race.cc
@@ -42,7 +42,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_test_helpers.h"
 #include "backup_debug.h"
 
-const int N=10;
 const int N_FNAMES = 2;
 
 void* do_backups(void *v) {

--- a/backup/tests/create_unlink_race.cc
+++ b/backup/tests/create_unlink_race.cc
@@ -42,7 +42,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_test_helpers.h"
 #include "backup_debug.h"
 
-const int N=10;
 const int N_FNAMES = 1;
 
 void* do_backups(void *v) {

--- a/backup/tests/disable_race.cc
+++ b/backup/tests/disable_race.cc
@@ -55,7 +55,7 @@ const int N = 16;
 static int fd_array[N] = {0};
 
 static void* write_ones(void *p) {
-    const int * const nth_ptr = (const int * const)p;
+    const int * const nth_ptr = reinterpret_cast<const int *>(p);
     const int nth_fd = *nth_ptr;
     char data[SIZE] = {ONE};
     int pwrite_r = write(fd_array[nth_fd], data, SIZE);

--- a/backup/tests/exclude_all_files.cc
+++ b/backup/tests/exclude_all_files.cc
@@ -119,7 +119,7 @@ static int check_it(char *dst, char *magic, int size, int count)
     if (backup_fd < 0) {
         perror("check_it() could not open destination file");
         printf("Expected file %s/magic%d apparently excluded from backup.\n", dst, count);
-        assert(_errno_ == ENOENT);
+        check(_errno_ == ENOENT);
         return 0;
     } else {
         printf("FAILURE: check_it() was able to open file %s/magic%d\n.", dst, count);
@@ -139,7 +139,7 @@ static int check_it(char *dst, char *magic, int size, int count)
     return r;
 }
 
-const int SIZE = 7;
+const int SIZE = 16;
 char buf[SIZE] = {0};
 
 struct SourceAndDestinationDirectories {

--- a/backup/tests/ftruncate_injection_6480.cc
+++ b/backup/tests/ftruncate_injection_6480.cc
@@ -48,8 +48,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_test_helpers.h"
 #include "real_syscalls.h"
 
-static const int ERRORS_TO_CHECK = 1;
-
 static int iteration = 0;
 
 const int ERROR = EIO;

--- a/backup/tests/lseek_write.cc
+++ b/backup/tests/lseek_write.cc
@@ -1,0 +1,117 @@
+/* -*- mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+// vim: ft=cpp:expandtab:ts=8:sw=4:softtabstop=4:
+/*======
+This file is part of Percona TokuBackup.
+
+Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
+
+    Percona TokuBackup is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License, version 2,
+    as published by the Free Software Foundation.
+
+     Percona TokuBackup is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Percona TokuBackup.  If not, see <http://www.gnu.org/licenses/>.
+
+----------------------------------------
+
+    Percona TokuBackup is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License, version 3,
+    as published by the Free Software Foundation.
+
+    Percona TokuBackup is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with Percona TokuBackup.  If not, see <http://www.gnu.org/licenses/>.
+======= */
+
+// Test that lseeks are intercepted by backup and executed while backup is
+// still capturing.
+
+#ident "$Id$"
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "backup.h"
+#include "backup_test_helpers.h"
+
+static int verify(void) {
+    char *src = get_src();
+    char *dst = get_dst();
+    int r = systemf("diff -r %s %s", src, dst);
+    free(src);
+    free(dst);
+    if (!WIFEXITED(r)) return -1;
+    if (WEXITSTATUS(r)!=0) return -1;
+    return 0;
+}
+
+int lseek_write_after_copy(void) {
+    int result = 0;
+    int fd = 0;
+    setup_source();
+    setup_dirs();
+    setup_destination();
+
+    // keep backup capturing until after the test executes the
+    // final lseek and write.
+    backup_set_keep_capturing(true);
+
+    // start backup
+    pthread_t thread;
+    start_backup_thread(&thread);
+
+    // create a source file and write at the beginning of the file
+    char *src = get_src();
+    fd = openf(O_CREAT | O_RDWR, 0777, "%s/my.data", src);
+    check(fd >= 0);
+    free(src);
+    result = write(fd, "Hello World\n", 12);
+    check(result == 12);
+
+    // wait for backup copy phase to copy the source file
+    while (!backup_done_copying()) {
+        sched_yield();
+    }
+
+    // write at 1M offset
+    const off_t next_write_offset = 1<<20;
+    result = lseek(fd, next_write_offset, SEEK_SET);
+    check(result == next_write_offset);
+    result = write(fd, "Cruel World\n", 12);
+    check(result == 12);
+
+    result = close(fd);
+    check(result == 0);
+
+    // wait for the backup to finish
+    backup_set_keep_capturing(false);
+    finish_backup_thread(thread);
+
+    // verify source and backup files
+    if(verify()) {
+        fail(); result = 1;
+    } else {
+        pass(); result = 0;
+    }
+    return result;
+}
+
+int test_main(int argc __attribute__((__unused__)), const char *argv[] __attribute__((__unused__))) {
+    int result = lseek_write_after_copy();
+    return result;
+}

--- a/backup/tests/many_directories.cc
+++ b/backup/tests/many_directories.cc
@@ -106,7 +106,7 @@ static int check_it(char *dst, char *magic, int size, int count)
     char backup_buf[20] = {0};
     int result = pread(backup_fd, backup_buf, size, 0);
     char magic_buf[20] = {0};
-    snprintf(magic_buf, size, "%s%d", magic, count);
+    { int magic_size = snprintf(magic_buf, size, "%s%d", magic, count); check(magic_size < size); }
     result = strcmp(backup_buf, magic_buf);
     if (result != 0) {
         printf("Couldn't match: source:%s vs backup:%s\n", magic_buf, backup_buf);
@@ -139,7 +139,7 @@ int many_directories(const int directory_count, const bool keep_capturing) {
     pthread_t thread; 
     start_backup_thread(&thread);
     // Do work in each directory.
-    const int SIZE = 7;
+    const int SIZE = 16;
     char buf[SIZE] = {0};
     for (int i = 0; i < directory_count; ++i)
     {

--- a/backup/tests/multiple_backups.cc
+++ b/backup/tests/multiple_backups.cc
@@ -127,7 +127,7 @@ static int check_it(char *magic, int size, int count)
         char backup_buf[20] = {0};
         int result = pread(backup_fd, backup_buf, size, 0);
         char magic_buf[20] = {0};
-        snprintf(magic_buf, size, "%s%d", magic, i);
+        { int magic_size = snprintf(magic_buf, size, "%s%d", magic, i); check(magic_size < size); }
         result = strcmp(backup_buf, magic_buf);
         if (result != 0) {
             printf("Couldn't match: source:%s vs backup:%s\n", magic_buf, backup_buf);

--- a/backup/tests/notinsource_6570.cc
+++ b/backup/tests/notinsource_6570.cc
@@ -116,7 +116,7 @@ int test_main(int argc __attribute__((__unused__)), const char *argv[] __attribu
     size_t slen = strlen(src);
     const char N_EXTRA_BYTES = 10;
     not_src = (char*)malloc(slen+N_EXTRA_BYTES);
-    strncpy(not_src, src, slen+N_EXTRA_BYTES);
+    strcpy(not_src, src);
     const char go_back_n_bytes = 7;
     printf("backed up =%s\n",not_src+slen-go_back_n_bytes);
     check(0==strcmp(not_src+slen-go_back_n_bytes, ".source"));

--- a/backup/tests/notinsource_6570b.cc
+++ b/backup/tests/notinsource_6570b.cc
@@ -198,7 +198,7 @@ int test_main(int argc __attribute__((__unused__)), const char *argv[] __attribu
     size_t slen = strlen(src);
     const char N_EXTRA_BYTES = 10;
     not_src = (char*)malloc(slen+N_EXTRA_BYTES);
-    strncpy(not_src, src, slen+N_EXTRA_BYTES);
+    strcpy(not_src, src);
     const char go_back_n_bytes = 7;
     printf("backed up =%s\n",not_src+slen-go_back_n_bytes);
     check(0==strcmp(not_src+slen-go_back_n_bytes, ".source"));

--- a/backup/tests/open_injection_6476.cc
+++ b/backup/tests/open_injection_6476.cc
@@ -48,8 +48,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_test_helpers.h"
 #include "real_syscalls.h"
 
-static const int ERRORS_TO_CHECK = 1;
-
 static volatile int iteration = 0;
 
 static open_fun_t original_open;

--- a/backup/tests/open_lseek_write.cc
+++ b/backup/tests/open_lseek_write.cc
@@ -1,0 +1,117 @@
+/* -*- mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+// vim: ft=cpp:expandtab:ts=8:sw=4:softtabstop=4:
+/*======
+This file is part of Percona TokuBackup.
+
+Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
+
+    Percona TokuBackup is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License, version 2,
+    as published by the Free Software Foundation.
+
+     Percona TokuBackup is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Percona TokuBackup.  If not, see <http://www.gnu.org/licenses/>.
+
+----------------------------------------
+
+    Percona TokuBackup is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License, version 3,
+    as published by the Free Software Foundation.
+
+    Percona TokuBackup is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with Percona TokuBackup.  If not, see <http://www.gnu.org/licenses/>.
+======= */
+
+// Test that opens, lseeks, and writes are intercepted by backup and executed while backup is
+// still capturing.
+
+#ident "$Id$"
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "backup.h"
+#include "backup_test_helpers.h"
+
+static int verify(void) {
+    char *src = get_src();
+    char *dst = get_dst();
+    int r = systemf("diff -r %s %s", src, dst);
+    free(src);
+    free(dst);
+    if (!WIFEXITED(r)) return -1;
+    if (WEXITSTATUS(r)!=0) return -1;
+    return 0;
+}
+
+int lseek_write_after_copy(void) {
+    int result = 0;
+    int fd = 0;
+    setup_source();
+    setup_dirs();
+    setup_destination();
+
+    // keep backup capturing until after the test executes the
+    // final lseek and write.
+    backup_set_keep_capturing(true);
+
+    // start backup
+    pthread_t thread;
+    start_backup_thread(&thread);
+
+    // wait for backup copy phase to copy the source file
+    while (!backup_done_copying()) {
+        sched_yield();
+    }
+
+    // create a source file and write at the beginning of the file
+    char *src = get_src();
+    fd = openf(O_CREAT | O_RDWR, 0777, "%s/my.data", src);
+    check(fd >= 0);
+    free(src);
+    result = write(fd, "Hello World\n", 12);
+    check(result == 12);
+
+    // write at 1M offset
+    const off_t next_write_offset = 1<<20;
+    result = lseek(fd, next_write_offset, SEEK_SET);
+    check(result == next_write_offset);
+    result = write(fd, "Cruel World\n", 12);
+    check(result == 12);
+
+    result = close(fd);
+    check(result == 0);
+
+    // wait for the backup to finish
+    backup_set_keep_capturing(false);
+    finish_backup_thread(thread);
+
+    // verify source and backup files
+    if(verify()) {
+        fail(); result = 1;
+    } else {
+        pass(); result = 0;
+    }
+    return result;
+}
+
+int test_main(int argc __attribute__((__unused__)), const char *argv[] __attribute__((__unused__))) {
+    int result = lseek_write_after_copy();
+    return result;
+}

--- a/backup/tests/pwrite_during_backup.cc
+++ b/backup/tests/pwrite_during_backup.cc
@@ -1,0 +1,115 @@
+/* -*- mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+// vim: ft=cpp:expandtab:ts=8:sw=4:softtabstop=4:
+/*======
+This file is part of Percona TokuBackup.
+
+Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
+
+    Percona TokuBackup is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License, version 2,
+    as published by the Free Software Foundation.
+
+     Percona TokuBackup is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Percona TokuBackup.  If not, see <http://www.gnu.org/licenses/>.
+
+----------------------------------------
+
+    Percona TokuBackup is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License, version 3,
+    as published by the Free Software Foundation.
+
+    Percona TokuBackup is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with Percona TokuBackup.  If not, see <http://www.gnu.org/licenses/>.
+======= */
+
+// Test that pwrites are intercepted during backup and executed on the backup
+// file.
+
+#ident "$Id$"
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "backup.h"
+#include "backup_test_helpers.h"
+
+static int verify(void) {
+    char *src = get_src();
+    char *dst = get_dst();
+    int r = systemf("diff -r %s %s", src, dst);
+    free(src);
+    free(dst);
+    if (!WIFEXITED(r)) return -1;
+    if (WEXITSTATUS(r)!=0) return -1;
+    return 0;
+}
+
+int lseek_write_after_copy(void) {
+    int result = 0;
+    int fd = 0;
+    setup_source();
+    setup_dirs();
+    setup_destination();
+
+    // keep backup capturing until after the test executes the
+    // final lseek and write.
+    backup_set_keep_capturing(true);
+
+    // start backup
+    pthread_t thread;
+    start_backup_thread(&thread);
+
+    // create a source file and write at the beginning of the file
+    char *src = get_src();
+    fd = openf(O_CREAT | O_RDWR, 0777, "%s/my.data", src);
+    check(fd >= 0);
+    free(src);
+    result = write(fd, "Hello World\n", 12);
+    check(result == 12);
+
+    // wait for backup copy phase to copy the source file
+    while (!backup_done_copying()) {
+        sched_yield();
+    }
+
+    // pwrite at 1M offset
+    const off_t next_write_offset = 1<<20;
+    result = pwrite(fd, "Cruel World\n", 12, next_write_offset);
+    check(result == 12);
+
+    result = close(fd);
+    check(result == 0);
+
+    // wait for the backup to finish
+    backup_set_keep_capturing(false);
+    finish_backup_thread(thread);
+
+    // verify source and backup files
+    if(verify()) {
+        fail(); result = 1;
+    } else {
+        pass(); result = 0;
+    }
+    return result;
+}
+
+int test_main(int argc __attribute__((__unused__)), const char *argv[] __attribute__((__unused__))) {
+    int result = lseek_write_after_copy();
+    return result;
+}

--- a/backup/tests/range_locks.cc
+++ b/backup/tests/range_locks.cc
@@ -54,7 +54,8 @@ static void* doit(void* ignore) {
 
 
     stepb = 1;
-    while (!stepc);
+    while (!stepc)
+      ;
     { int r = sf.unlock_range(doit_lo, doit_hi); check(r==0); }
 
     return ignore;

--- a/backup/tests/rename_injection.cc
+++ b/backup/tests/rename_injection.cc
@@ -48,8 +48,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_test_helpers.h"
 #include "real_syscalls.h"
 
-static const int ERRORS_TO_CHECK = 1;
-
 static volatile int iteration = 0;
 
 static rename_fun_t original_rename;

--- a/backup/tests/two_renames_race.cc
+++ b/backup/tests/two_renames_race.cc
@@ -43,7 +43,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_test_helpers.h"
 #include "backup_debug.h"
 
-const int N=10;
 const int N_FNAMES = 2;
 
 void* do_backups(void *v) {

--- a/backup/tests/unlink_injection.cc
+++ b/backup/tests/unlink_injection.cc
@@ -48,8 +48,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_test_helpers.h"
 #include "real_syscalls.h"
 
-static const int ERRORS_TO_CHECK = 1;
-
 static volatile int iteration = 0;
 
 static unlink_fun_t original_unlink;


### PR DESCRIPTION
Tokubackup is broken because the large file contract expected by applications that
use tokubackup is no longer exported by tokubackup.  The contract was broken by commit
0ab06b5ba05d0cb4183326599eb47f898b8cccf3 made in early 2018.

The large file contract is supported by compiling with -D_LARGEFILE64_SOURCE and
-D_FILE_OFFSET_BITS=64 AND including the appropriate include files.  When an
application is compiled with large file support, it has link time dependencies
to the large file API.  For example, the compiler causes calls to pwrite
to refer to pwrite64.

The hot backup library MUST export pwrite64.  The broken commit removes the include
of unistd.h, which removes the large file link time trickery.  The result is that
the hot backup library exports pwrite instead of pwrite64.

The effect is that pwrite calls made by the application are NOT intercepted by tokubackup.
Therefore, the backup files are no longer consistent with each other when the backup
completes.  

This pull request:
Fixes the compilation of the tests.
Adds tests for lseek and pwrite during the backup.
Reverts the commit that broke the large file API contract.

Tools:
Ubuntu 19.10, Clang 7,8,9, Gcc 7,8,9, Cmake 3.14

Directions:
CXXFLAGS=-fsanitize=thread CC=clang CXX=clang++ cmake -D CMAKE_BUILD_TYPE=Debug ..
make
ctest

Copyright (c) 2020, Rik Prohaska
All rights reserved.

Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.