### PR TITLE
PS-6946 : Sanitizers find memory use after free and other issues in tokubackup

### DIFF
--- a/backup/CMakeLists.txt
+++ b/backup/CMakeLists.txt
@@ -8,6 +8,7 @@ project(HotBackup)
 
 
 # pick language dialect
+include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag(-std=c++11 HAVE_STDCXX11)
 if (HAVE_STDCXX11)
   set(CMAKE_CXX_FLAGS "-std=c++11 -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS}")

--- a/backup/backup.cc
+++ b/backup/backup.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #include <stdio.h> // rename(),
 #include <fcntl.h> // open()
+#include <unistd.h> // close(), write(), read(), unlink(), truncate(), etc.
 #include <sys/stat.h> // mkdir()
 #include <errno.h>
 #include <dlfcn.h>

--- a/backup/backup.h
+++ b/backup/backup.h
@@ -63,10 +63,10 @@ int tokubackup_create_backup(const char *source_dirs[],
                              void *error_extra,
                              backup_exclude_copy_fun_t check_fun,
                              void *exclude_copy_extra,
-                             backup_before_stop_capt_fun_t bsc_fun,
-                             void *bsc_extra,
-                             backup_after_stop_capt_fun_t asc_fun,
-                             void *asc_extra)
+                             backup_before_stop_capt_fun_t bsc_fun = nullptr,
+                             void *bsc_extra = nullptr,
+                             backup_after_stop_capt_fun_t asc_fun = nullptr,
+                             void *asc_extra = nullptr)
     throw() __attribute__((visibility("default")));
 // Effect: Backup the directories in source_dirs into correspnding dest_dirs.
 // Periodically call poll_fun.

--- a/backup/backup_callbacks.h
+++ b/backup/backup_callbacks.h
@@ -54,10 +54,10 @@ public:
                      backup_exclude_copy_fun_t exclude_copy_fun,
                      void *exclude_copy_extra,
                      backup_throttle_fun_t throttle_fun,
-                     backup_before_stop_capt_fun_t bsc_fun,
-                     void *bsc_extra,
-                     backup_after_stop_capt_fun_t asc_fun,
-                     void *asc_extra) throw();
+                     backup_before_stop_capt_fun_t bsc_fun = nullptr,
+                     void *bsc_extra = nullptr,
+                     backup_after_stop_capt_fun_t asc_fun = nullptr,
+                     void *asc_extra = nullptr) throw();
     int poll(float progress, const char *progress_string) throw();
     void report_error(int error_number, const char *error_description) throw();
     unsigned long get_throttle(void) throw();

--- a/backup/backup_debug.cc
+++ b/backup/backup_debug.cc
@@ -37,6 +37,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_debug.h"
 #include "backup_helgrind.h"
 #include <stdio.h>
+#include <atomic>
 
 namespace HotBackup {
 
@@ -117,7 +118,7 @@ void InterposeError(const char *s, const char *arg) throw() {
     }
 }
 
-static int PAUSE_POINTS = 0x00;
+static std::atomic_int PAUSE_POINTS = { 0x00 };
 
 bool should_pause(int flag) throw() {
     bool result = false;
@@ -155,7 +156,7 @@ bool should_pause(int flag) throw() {
 
 void toggle_pause_point(int flag) throw() {
     TOKUBACKUP_VALGRIND_HG_DISABLE_CHECKING(&PAUSE_POINTS, sizeof(PAUSE_POINTS));
-    PAUSE_POINTS = PAUSE_POINTS ^ flag;
+    PAUSE_POINTS ^= flag;
 }
 
 } // End of namespace.

--- a/backup/copier.cc
+++ b/backup/copier.cc
@@ -150,7 +150,7 @@ int copier::do_copy(void) throw() {
         
         {
             with_mutex_locked tm(&m_todo_mutex, BACKTRACE(NULL));
-            fname = m_todo.back();
+            fname = m_todo.front();
         }
         TRACE("Copying: ", fname);
         
@@ -166,7 +166,7 @@ int copier::do_copy(void) throw() {
 
         {
             with_mutex_locked tm(&m_todo_mutex, BACKTRACE(NULL));
-            m_todo.pop_back();
+            m_todo.pop_front();
         }
         
         r = this->copy_stripped_file(fname);

--- a/backup/copier.h
+++ b/backup/copier.h
@@ -43,7 +43,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #include <stdint.h>
 #include <sys/types.h>
-#include <vector>
+#include <deque>
 #include <dirent.h>
 #include <pthread.h>
 
@@ -93,7 +93,7 @@ class copier {
   private:
     const char *m_source;
     const char *m_dest;
-    std::vector<char *> m_todo;
+    std::deque<char *> m_todo;
     backup_callbacks *m_calls;
     file_hash_table * const m_table;
     size_t m_total_written_this_file;

--- a/backup/manager.cc
+++ b/backup/manager.cc
@@ -367,8 +367,9 @@ int manager::open(int fd, const char *file, int flags) throw() {
     // First, get the description and source_file objects associated
     // with the given fd.
     m_map.get(fd, &description, BACKTRACE(NULL));
-    
     source = description->get_source_file();
+
+    with_file_hash_table_mutex mtl(&m_table);
     with_source_file_name_read_lock sfl(source);
 
     // Next, determine the full path of the backup file.

--- a/backup/manager.h
+++ b/backup/manager.h
@@ -62,7 +62,6 @@ private:
     volatile bool m_done_copying;   // Backup manager sets this true when copying is done.  Happens after m_is_captring
 #endif
 
-    volatile bool m_is_dead; // true if some error occured so that the backup system shouldn't try any more.
     volatile bool m_backup_is_running; // true if the backup is running.  This can be accessed without any locks.
 
     fmap m_map;

--- a/backup/manager.h
+++ b/backup/manager.h
@@ -49,17 +49,18 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include <stdarg.h>
 #include <sys/types.h>
 #include <vector>
+#include <atomic>
 
 class manager : public manager_state
 {
 private:
 
 #ifdef GLASSBOX
-    volatile bool m_pause_disable;
-    volatile bool m_start_copying; // For test purposes, we can arrange to initialize the backup but not actually start copying.
-    volatile bool m_keep_capturing; // For test purposes, we can arrange to keep capturing the backup until the client tells us to stop.
-    volatile bool m_is_capturing;   // Backup manager sets to true when capturing is running, sets to false when capturing has stopped.   We look at m_start_copying after setting m_is_capturing=true.
-    volatile bool m_done_copying;   // Backup manager sets this true when copying is done.  Happens after m_is_captring
+    std::atomic_bool m_pause_disable;
+    std::atomic_bool m_start_copying; // For test purposes, we can arrange to initialize the backup but not actually start copying.
+    std::atomic_bool m_keep_capturing; // For test purposes, we can arrange to keep capturing the backup until the client tells us to stop.
+    std::atomic_bool m_is_capturing;   // Backup manager sets to true when capturing is running, sets to false when capturing has stopped.   We look at m_start_copying after setting m_is_capturing=true.
+    std::atomic_bool m_done_copying;   // Backup manager sets this true when copying is done.  Happens after m_is_captring
 #endif
 
     volatile bool m_backup_is_running; // true if the backup is running.  This can be accessed without any locks.
@@ -74,7 +75,7 @@ private:
     backup_session *m_session;
     static pthread_rwlock_t m_session_rwlock;
 
-    volatile unsigned long m_throttle;
+    std::atomic_ulong m_throttle;
 
     // Error handling.
     static pthread_mutex_t m_error_mutex;     // When testing errors grab this mutex. 

--- a/backup/manager_state.h
+++ b/backup/manager_state.h
@@ -38,6 +38,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #ident "$Id$"
 
 #include <pthread.h>
+#include <atomic>
 
 class manager_state {
 public:
@@ -53,9 +54,9 @@ protected:
     void enable_copy(void) throw();
     void disable_copy(void) throw();
 private:
-    volatile bool m_is_dead;
-    volatile bool m_capture_enabled;
-    volatile bool m_copy_enabled;
+    std::atomic_bool m_is_dead;
+    std::atomic_bool m_capture_enabled;
+    std::atomic_bool m_copy_enabled;
 };
 
 #endif // End of header guardian.

--- a/backup/source_file.cc
+++ b/backup/source_file.cc
@@ -221,7 +221,7 @@ int source_file::rename(const char * new_name) throw() {
 ////////////////////////////////////////////////////////
 //
 void source_file::add_reference(void) throw() {
-    __sync_fetch_and_add(&m_reference_count, 1);
+    m_reference_count.fetch_add(1);
 }
 
 ////////////////////////////////////////////////////////
@@ -229,7 +229,7 @@ void source_file::add_reference(void) throw() {
 void source_file::remove_reference(void) throw() {
     // TODO.  How can the code that decremented a reference count only if it was positive be right?  Under what conditions could someone be decrementing a refcount when they don't know that it's positive?
     check(m_reference_count>0);
-    __sync_fetch_and_add(&m_reference_count, -1);
+    m_reference_count.fetch_add(-1);
 }
 
 ////////////////////////////////////////////////////////

--- a/backup/source_file.cc
+++ b/backup/source_file.cc
@@ -104,6 +104,11 @@ source_file::~source_file(void) throw() {
             check(r==0);
         }
     }
+
+    if (m_destination_file != NULL) {
+        delete m_destination_file;
+        m_destination_file = NULL;
+    }
 }
 
 ////////////////////////////////////////////////////////

--- a/backup/source_file.h
+++ b/backup/source_file.h
@@ -38,6 +38,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #define SOURCE_FILE_H
 
 #include <stdint.h>
+#include <atomic>
 
 #include "destination_file.h"
 #include "description.h"
@@ -104,7 +105,7 @@ private:
     char * m_full_path; // the source_file owns this.
     source_file *m_next;
     pthread_rwlock_t m_name_rwlock;
-    unsigned int m_reference_count;
+    std::atomic_uint m_reference_count;
 
     pthread_mutex_t  m_mutex;
     pthread_cond_t   m_cond;

--- a/backup/tests/CMakeLists.txt
+++ b/backup/tests/CMakeLists.txt
@@ -83,6 +83,9 @@ set(glassboxtests
   unlink_during_copy_test6515c
   unlink_injection
   write_race
+  lseek_write
+  open_lseek_write
+  pwrite_during_backup
   )
 
 set(glassboxtests_no_grind

--- a/backup/tests/abort_while_holding_lock.cc
+++ b/backup/tests/abort_while_holding_lock.cc
@@ -83,19 +83,19 @@ int test_main(int argc __attribute__((unused)), const char *argv[] __attribute__
     setup_source();
     char *src = get_src();
     size_t len = strlen(src)+100;
-    A = (char*)malloc(len); { int r = snprintf(A, len, "%s/A", src); assert(size_t(r)<len); }
-    B = (char*)malloc(len); { int r = snprintf(B, len, "%s/B", src); assert(size_t(r)<len); }
-    C = (char*)malloc(len); { int r = snprintf(A, len, "%s/C", src); assert(size_t(r)<len); }
-    D = (char*)malloc(len); { int r = snprintf(B, len, "%s/D", src); assert(size_t(r)<len); }
+    A = (char*)malloc(len); { int r = snprintf(A, len, "%s/A", src); check(size_t(r)<len); }
+    B = (char*)malloc(len); { int r = snprintf(B, len, "%s/B", src); check(size_t(r)<len); }
+    C = (char*)malloc(len); { int r = snprintf(A, len, "%s/C", src); check(size_t(r)<len); }
+    D = (char*)malloc(len); { int r = snprintf(B, len, "%s/D", src); check(size_t(r)<len); }
     {
         int fd = open(A, O_WRONLY | O_CREAT, 0777);
-        assert(fd>=0);
+        check(fd>=0);
         int r = close(fd);
-        assert(r==0);
+        check(r==0);
     }
     {
         int r = rename(A, B);
-        assert(r==0);
+        check(r==0);
     }
     cleanup_dirs();
     free(src);

--- a/backup/tests/abort_while_holding_lock.cc
+++ b/backup/tests/abort_while_holding_lock.cc
@@ -39,7 +39,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 // running abort(), or some signal handler that abort might call, an
 // I/O happens that might try to grab that lock if the backup system
 // is running.  This is covered in git issue #24.
-
+#undef NDEBUG
 #include <assert.h>
 #include <fcntl.h>
 #include <signal.h>

--- a/backup/tests/abort_while_holding_lock.cc
+++ b/backup/tests/abort_while_holding_lock.cc
@@ -85,8 +85,8 @@ int test_main(int argc __attribute__((unused)), const char *argv[] __attribute__
     size_t len = strlen(src)+100;
     A = (char*)malloc(len); { int r = snprintf(A, len, "%s/A", src); check(size_t(r)<len); }
     B = (char*)malloc(len); { int r = snprintf(B, len, "%s/B", src); check(size_t(r)<len); }
-    C = (char*)malloc(len); { int r = snprintf(A, len, "%s/C", src); check(size_t(r)<len); }
-    D = (char*)malloc(len); { int r = snprintf(B, len, "%s/D", src); check(size_t(r)<len); }
+    C = (char*)malloc(len); { int r = snprintf(C, len, "%s/C", src); check(size_t(r)<len); }
+    D = (char*)malloc(len); { int r = snprintf(D, len, "%s/D", src); check(size_t(r)<len); }
     {
         int fd = open(A, O_WRONLY | O_CREAT, 0777);
         check(fd>=0);

--- a/backup/tests/backup_test_helpers.cc
+++ b/backup/tests/backup_test_helpers.cc
@@ -150,7 +150,7 @@ struct backup_thread_extra_t {
     int                expect_return_result;
 };
 
-static volatile bool backup_is_done = false;
+static std::atomic_bool backup_is_done = {false};
 
 static void* start_backup_thread_fun(void *backup_extra_v) {
     backup_thread_extra_t *backup_extra = (backup_thread_extra_t*)backup_extra_v;
@@ -350,6 +350,7 @@ int main (int argc, const char *argv[]) {
             argnum++;
         } else {
             new_argv[new_argc++] = argv[argnum];
+            argnum++;
         }
     }
     if (test_name==NULL) test_name=argv[0]; // make the function work with no arguments.

--- a/backup/tests/backup_test_helpers.h
+++ b/backup/tests/backup_test_helpers.h
@@ -41,6 +41,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_internal.h"
 #include <pthread.h>
 #include <time.h>
+#include <atomic>
 
 int systemf(const char formatstring, ...); // Effect: run system on the snprintf of the format string and args.
 

--- a/backup/tests/create_rename_race.cc
+++ b/backup/tests/create_rename_race.cc
@@ -42,7 +42,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_test_helpers.h"
 #include "backup_debug.h"
 
-const int N=10;
 const int N_FNAMES = 2;
 
 void* do_backups(void *v) {

--- a/backup/tests/create_unlink_race.cc
+++ b/backup/tests/create_unlink_race.cc
@@ -42,7 +42,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_test_helpers.h"
 #include "backup_debug.h"
 
-const int N=10;
 const int N_FNAMES = 1;
 
 void* do_backups(void *v) {

--- a/backup/tests/disable_race.cc
+++ b/backup/tests/disable_race.cc
@@ -55,7 +55,7 @@ const int N = 16;
 static int fd_array[N] = {0};
 
 static void* write_ones(void *p) {
-    const int * const nth_ptr = (const int * const)p;
+    const int * const nth_ptr = reinterpret_cast<const int *>(p);
     const int nth_fd = *nth_ptr;
     char data[SIZE] = {ONE};
     int pwrite_r = write(fd_array[nth_fd], data, SIZE);

--- a/backup/tests/exclude_all_files.cc
+++ b/backup/tests/exclude_all_files.cc
@@ -34,6 +34,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "$Id$"
 
+#undef NDEBUG
 #include <assert.h>
 #include <errno.h>
 #include <sys/stat.h>

--- a/backup/tests/exclude_all_files.cc
+++ b/backup/tests/exclude_all_files.cc
@@ -119,7 +119,7 @@ static int check_it(char *dst, char *magic, int size, int count)
     if (backup_fd < 0) {
         perror("check_it() could not open destination file");
         printf("Expected file %s/magic%d apparently excluded from backup.\n", dst, count);
-        assert(_errno_ == ENOENT);
+        check(_errno_ == ENOENT);
         return 0;
     } else {
         printf("FAILURE: check_it() was able to open file %s/magic%d\n.", dst, count);
@@ -139,7 +139,7 @@ static int check_it(char *dst, char *magic, int size, int count)
     return r;
 }
 
-const int SIZE = 7;
+const int SIZE = 16;
 char buf[SIZE] = {0};
 
 struct SourceAndDestinationDirectories {

--- a/backup/tests/ftruncate_injection_6480.cc
+++ b/backup/tests/ftruncate_injection_6480.cc
@@ -48,8 +48,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_test_helpers.h"
 #include "real_syscalls.h"
 
-static const int ERRORS_TO_CHECK = 1;
-
 static int iteration = 0;
 
 const int ERROR = EIO;

--- a/backup/tests/lseek_write.cc
+++ b/backup/tests/lseek_write.cc
@@ -1,0 +1,117 @@
+/* -*- mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+// vim: ft=cpp:expandtab:ts=8:sw=4:softtabstop=4:
+/*======
+This file is part of Percona TokuBackup.
+
+Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
+
+    Percona TokuBackup is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License, version 2,
+    as published by the Free Software Foundation.
+
+     Percona TokuBackup is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Percona TokuBackup.  If not, see <http://www.gnu.org/licenses/>.
+
+----------------------------------------
+
+    Percona TokuBackup is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License, version 3,
+    as published by the Free Software Foundation.
+
+    Percona TokuBackup is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with Percona TokuBackup.  If not, see <http://www.gnu.org/licenses/>.
+======= */
+
+// Test that lseeks are intercepted by backup and executed while backup is
+// still capturing.
+
+#ident "$Id$"
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "backup.h"
+#include "backup_test_helpers.h"
+
+static int verify(void) {
+    char *src = get_src();
+    char *dst = get_dst();
+    int r = systemf("diff -r %s %s", src, dst);
+    free(src);
+    free(dst);
+    if (!WIFEXITED(r)) return -1;
+    if (WEXITSTATUS(r)!=0) return -1;
+    return 0;
+}
+
+int lseek_write_after_copy(void) {
+    int result = 0;
+    int fd = 0;
+    setup_source();
+    setup_dirs();
+    setup_destination();
+
+    // keep backup capturing until after the test executes the
+    // final lseek and write.
+    backup_set_keep_capturing(true);
+
+    // start backup
+    pthread_t thread;
+    start_backup_thread(&thread);
+
+    // create a source file and write at the beginning of the file
+    char *src = get_src();
+    fd = openf(O_CREAT | O_RDWR, 0777, "%s/my.data", src);
+    check(fd >= 0);
+    free(src);
+    result = write(fd, "Hello World\n", 12);
+    check(result == 12);
+
+    // wait for backup copy phase to copy the source file
+    while (!backup_done_copying()) {
+        sched_yield();
+    }
+
+    // write at 1M offset
+    const off_t next_write_offset = 1<<20;
+    result = lseek(fd, next_write_offset, SEEK_SET);
+    check(result == next_write_offset);
+    result = write(fd, "Cruel World\n", 12);
+    check(result == 12);
+
+    result = close(fd);
+    check(result == 0);
+
+    // wait for the backup to finish
+    backup_set_keep_capturing(false);
+    finish_backup_thread(thread);
+
+    // verify source and backup files
+    if(verify()) {
+        fail(); result = 1;
+    } else {
+        pass(); result = 0;
+    }
+    return result;
+}
+
+int test_main(int argc __attribute__((__unused__)), const char *argv[] __attribute__((__unused__))) {
+    int result = lseek_write_after_copy();
+    return result;
+}

--- a/backup/tests/many_directories.cc
+++ b/backup/tests/many_directories.cc
@@ -106,7 +106,7 @@ static int check_it(char *dst, char *magic, int size, int count)
     char backup_buf[20] = {0};
     int result = pread(backup_fd, backup_buf, size, 0);
     char magic_buf[20] = {0};
-    snprintf(magic_buf, size, "%s%d", magic, count);
+    { int magic_size = snprintf(magic_buf, size, "%s%d", magic, count); check(magic_size < size); }
     result = strcmp(backup_buf, magic_buf);
     if (result != 0) {
         printf("Couldn't match: source:%s vs backup:%s\n", magic_buf, backup_buf);
@@ -139,7 +139,7 @@ int many_directories(const int directory_count, const bool keep_capturing) {
     pthread_t thread; 
     start_backup_thread(&thread);
     // Do work in each directory.
-    const int SIZE = 7;
+    const int SIZE = 16;
     char buf[SIZE] = {0};
     for (int i = 0; i < directory_count; ++i)
     {

--- a/backup/tests/multiple_backups.cc
+++ b/backup/tests/multiple_backups.cc
@@ -127,7 +127,7 @@ static int check_it(char *magic, int size, int count)
         char backup_buf[20] = {0};
         int result = pread(backup_fd, backup_buf, size, 0);
         char magic_buf[20] = {0};
-        snprintf(magic_buf, size, "%s%d", magic, i);
+        { int magic_size = snprintf(magic_buf, size, "%s%d", magic, i); check(magic_size < size); }
         result = strcmp(backup_buf, magic_buf);
         if (result != 0) {
             printf("Couldn't match: source:%s vs backup:%s\n", magic_buf, backup_buf);

--- a/backup/tests/notinsource_6570.cc
+++ b/backup/tests/notinsource_6570.cc
@@ -116,7 +116,7 @@ int test_main(int argc __attribute__((__unused__)), const char *argv[] __attribu
     size_t slen = strlen(src);
     const char N_EXTRA_BYTES = 10;
     not_src = (char*)malloc(slen+N_EXTRA_BYTES);
-    strncpy(not_src, src, slen+N_EXTRA_BYTES);
+    strcpy(not_src, src);
     const char go_back_n_bytes = 7;
     printf("backed up =%s\n",not_src+slen-go_back_n_bytes);
     check(0==strcmp(not_src+slen-go_back_n_bytes, ".source"));

--- a/backup/tests/notinsource_6570b.cc
+++ b/backup/tests/notinsource_6570b.cc
@@ -198,7 +198,7 @@ int test_main(int argc __attribute__((__unused__)), const char *argv[] __attribu
     size_t slen = strlen(src);
     const char N_EXTRA_BYTES = 10;
     not_src = (char*)malloc(slen+N_EXTRA_BYTES);
-    strncpy(not_src, src, slen+N_EXTRA_BYTES);
+    strcpy(not_src, src);
     const char go_back_n_bytes = 7;
     printf("backed up =%s\n",not_src+slen-go_back_n_bytes);
     check(0==strcmp(not_src+slen-go_back_n_bytes, ".source"));

--- a/backup/tests/open_injection_6476.cc
+++ b/backup/tests/open_injection_6476.cc
@@ -48,8 +48,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_test_helpers.h"
 #include "real_syscalls.h"
 
-static const int ERRORS_TO_CHECK = 1;
-
 static volatile int iteration = 0;
 
 static open_fun_t original_open;

--- a/backup/tests/open_lseek_write.cc
+++ b/backup/tests/open_lseek_write.cc
@@ -1,0 +1,117 @@
+/* -*- mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+// vim: ft=cpp:expandtab:ts=8:sw=4:softtabstop=4:
+/*======
+This file is part of Percona TokuBackup.
+
+Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
+
+    Percona TokuBackup is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License, version 2,
+    as published by the Free Software Foundation.
+
+     Percona TokuBackup is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Percona TokuBackup.  If not, see <http://www.gnu.org/licenses/>.
+
+----------------------------------------
+
+    Percona TokuBackup is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License, version 3,
+    as published by the Free Software Foundation.
+
+    Percona TokuBackup is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with Percona TokuBackup.  If not, see <http://www.gnu.org/licenses/>.
+======= */
+
+// Test that opens, lseeks, and writes are intercepted by backup and executed while backup is
+// still capturing.
+
+#ident "$Id$"
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "backup.h"
+#include "backup_test_helpers.h"
+
+static int verify(void) {
+    char *src = get_src();
+    char *dst = get_dst();
+    int r = systemf("diff -r %s %s", src, dst);
+    free(src);
+    free(dst);
+    if (!WIFEXITED(r)) return -1;
+    if (WEXITSTATUS(r)!=0) return -1;
+    return 0;
+}
+
+int lseek_write_after_copy(void) {
+    int result = 0;
+    int fd = 0;
+    setup_source();
+    setup_dirs();
+    setup_destination();
+
+    // keep backup capturing until after the test executes the
+    // final lseek and write.
+    backup_set_keep_capturing(true);
+
+    // start backup
+    pthread_t thread;
+    start_backup_thread(&thread);
+
+    // wait for backup copy phase to copy the source file
+    while (!backup_done_copying()) {
+        sched_yield();
+    }
+
+    // create a source file and write at the beginning of the file
+    char *src = get_src();
+    fd = openf(O_CREAT | O_RDWR, 0777, "%s/my.data", src);
+    check(fd >= 0);
+    free(src);
+    result = write(fd, "Hello World\n", 12);
+    check(result == 12);
+
+    // write at 1M offset
+    const off_t next_write_offset = 1<<20;
+    result = lseek(fd, next_write_offset, SEEK_SET);
+    check(result == next_write_offset);
+    result = write(fd, "Cruel World\n", 12);
+    check(result == 12);
+
+    result = close(fd);
+    check(result == 0);
+
+    // wait for the backup to finish
+    backup_set_keep_capturing(false);
+    finish_backup_thread(thread);
+
+    // verify source and backup files
+    if(verify()) {
+        fail(); result = 1;
+    } else {
+        pass(); result = 0;
+    }
+    return result;
+}
+
+int test_main(int argc __attribute__((__unused__)), const char *argv[] __attribute__((__unused__))) {
+    int result = lseek_write_after_copy();
+    return result;
+}

--- a/backup/tests/open_prepare_race_6610.cc
+++ b/backup/tests/open_prepare_race_6610.cc
@@ -43,7 +43,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 static char *src;
 
-static volatile int n_backups_done = 0;
+static std::atomic_int n_backups_done = {0};
 static const int n_backups_to_do = 4;
 
 static void* open_close_loop(void * ignore) {
@@ -72,7 +72,7 @@ int test_main(int argc, const char *argv[] __attribute__((__unused__))) {
         setup_destination();
         start_backup_thread(&bth);
         finish_backup_thread(bth);
-        __sync_fetch_and_add(&n_backups_done, 1);
+        n_backups_done.fetch_add(1);
     }
     {
         void *result;

--- a/backup/tests/open_write_close.cc
+++ b/backup/tests/open_write_close.cc
@@ -42,7 +42,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include <unistd.h>
 #include <string.h>
 #include "backup_helgrind.h"
-
 #include "backup.h"
 #include "backup_test_helpers.h"
 
@@ -63,7 +62,7 @@ static int verify(void)
     return r;
 }
 
-volatile int write_done = 0;
+std::atomic_int write_done = {0};
 
 static int write_poll(float progress, const char *progress_string, void *extra) {
     check(0<=progress && progress<1);

--- a/backup/tests/open_write_race.cc
+++ b/backup/tests/open_write_race.cc
@@ -40,7 +40,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #include "backup_test_helpers.h"
 
-volatile long counter = 2; // so we know that all the work is done.
+std::atomic_long counter = {2}; // so we know that all the work is done.
 
 char *src; 
 
@@ -69,7 +69,7 @@ void* do_writes(void *v) {
         wcount++;
         printf(".");
     }
-    __sync_fetch_and_add(&counter, -1); // let do_backups know we finished.
+    counter.fetch_add(-1); // let do_backups know we finished.
     return v;
 }    
 
@@ -87,7 +87,7 @@ void* do_opens(void *v) {
         int r = close(fds[i]);
         check(r==0);
     }
-    __sync_fetch_and_add(&counter, -1); // done doing the opens
+    counter.fetch_add(-1); // done doing the opens
     return v;
 }
 

--- a/backup/tests/pwrite_during_backup.cc
+++ b/backup/tests/pwrite_during_backup.cc
@@ -1,0 +1,115 @@
+/* -*- mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+// vim: ft=cpp:expandtab:ts=8:sw=4:softtabstop=4:
+/*======
+This file is part of Percona TokuBackup.
+
+Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
+
+    Percona TokuBackup is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License, version 2,
+    as published by the Free Software Foundation.
+
+     Percona TokuBackup is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Percona TokuBackup.  If not, see <http://www.gnu.org/licenses/>.
+
+----------------------------------------
+
+    Percona TokuBackup is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License, version 3,
+    as published by the Free Software Foundation.
+
+    Percona TokuBackup is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with Percona TokuBackup.  If not, see <http://www.gnu.org/licenses/>.
+======= */
+
+// Test that pwrites are intercepted during backup and executed on the backup
+// file.
+
+#ident "$Id$"
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "backup.h"
+#include "backup_test_helpers.h"
+
+static int verify(void) {
+    char *src = get_src();
+    char *dst = get_dst();
+    int r = systemf("diff -r %s %s", src, dst);
+    free(src);
+    free(dst);
+    if (!WIFEXITED(r)) return -1;
+    if (WEXITSTATUS(r)!=0) return -1;
+    return 0;
+}
+
+int lseek_write_after_copy(void) {
+    int result = 0;
+    int fd = 0;
+    setup_source();
+    setup_dirs();
+    setup_destination();
+
+    // keep backup capturing until after the test executes the
+    // final lseek and write.
+    backup_set_keep_capturing(true);
+
+    // start backup
+    pthread_t thread;
+    start_backup_thread(&thread);
+
+    // create a source file and write at the beginning of the file
+    char *src = get_src();
+    fd = openf(O_CREAT | O_RDWR, 0777, "%s/my.data", src);
+    check(fd >= 0);
+    free(src);
+    result = write(fd, "Hello World\n", 12);
+    check(result == 12);
+
+    // wait for backup copy phase to copy the source file
+    while (!backup_done_copying()) {
+        sched_yield();
+    }
+
+    // pwrite at 1M offset
+    const off_t next_write_offset = 1<<20;
+    result = pwrite(fd, "Cruel World\n", 12, next_write_offset);
+    check(result == 12);
+
+    result = close(fd);
+    check(result == 0);
+
+    // wait for the backup to finish
+    backup_set_keep_capturing(false);
+    finish_backup_thread(thread);
+
+    // verify source and backup files
+    if(verify()) {
+        fail(); result = 1;
+    } else {
+        pass(); result = 0;
+    }
+    return result;
+}
+
+int test_main(int argc __attribute__((__unused__)), const char *argv[] __attribute__((__unused__))) {
+    int result = lseek_write_after_copy();
+    return result;
+}

--- a/backup/tests/range_locks.cc
+++ b/backup/tests/range_locks.cc
@@ -54,7 +54,8 @@ static void* doit(void* ignore) {
 
 
     stepb = 1;
-    while (!stepc);
+    while (!stepc)
+      ;
     { int r = sf.unlock_range(doit_lo, doit_hi); check(r==0); }
 
     return ignore;

--- a/backup/tests/realpath_error_injection.cc
+++ b/backup/tests/realpath_error_injection.cc
@@ -108,7 +108,7 @@ void call_unlink(const char * const file)
 }
 
 static realpath_fun_t original_realpath = NULL;
-volatile static bool inject_realpath_error = false;
+static std::atomic_bool inject_realpath_error = {false};
 char *my_realpath(const char *path, char *result) {
     if (inject_realpath_error) {
         errno = realpath_error_to_inject;

--- a/backup/tests/rename_injection.cc
+++ b/backup/tests/rename_injection.cc
@@ -48,8 +48,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_test_helpers.h"
 #include "real_syscalls.h"
 
-static const int ERRORS_TO_CHECK = 1;
-
 static volatile int iteration = 0;
 
 static rename_fun_t original_rename;

--- a/backup/tests/two_renames_race.cc
+++ b/backup/tests/two_renames_race.cc
@@ -43,7 +43,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_test_helpers.h"
 #include "backup_debug.h"
 
-const int N=10;
 const int N_FNAMES = 2;
 
 void* do_backups(void *v) {

--- a/backup/tests/two_renames_race.cc
+++ b/backup/tests/two_renames_race.cc
@@ -82,7 +82,7 @@ void* do_rename(void *p) {
     return p;
 }
 
-int test_main(int argc __attribute__((__unused__)), const char *argv[] __attribute__((__unused__))) {
+int test_two_renames(void) {
     int r = 0;
     setup_source();
     setup_destination();
@@ -156,5 +156,21 @@ int test_main(int argc __attribute__((__unused__)), const char *argv[] __attribu
 
     //    cleanup_dirs();
     free((void*)src);
+    return r;
+}
+
+int test_main(int argc, const char *argv[]) {
+    int ntests = 1;
+    for (int i=1; i<argc; i++) {
+        if (strcmp(argv[i], "--ntests") == 0 && i+1 < argc) {
+            ntests = atoi(argv[++i]);
+        }
+    }
+    int r = 0;
+    for (int i=0; i<ntests; i++) {
+        r = test_two_renames();
+        if (r != 0)
+            break;
+    }
     return r;
 }

--- a/backup/tests/unlink_injection.cc
+++ b/backup/tests/unlink_injection.cc
@@ -48,8 +48,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "backup_test_helpers.h"
 #include "real_syscalls.h"
 
-static const int ERRORS_TO_CHECK = 1;
-
 static volatile int iteration = 0;
 
 static unlink_fun_t original_unlink;

--- a/backup/tsan.suppressions
+++ b/backup/tsan.suppressions
@@ -1,0 +1,4 @@
+signal:operator delete
+race:dlvsym_set
+
+


### PR DESCRIPTION
The address and thread sanitizers found some issues in the tokubackup software
when running the tokubackup tests.

This pull request:
1. Fixes trivial data races in the tests found by the thread sanitizer.  This
allows one to focus on important issues.
2. Fixes a heap use after free problem detected by the thread sanitizer.  The
solution replaces the use of std vector with std deque to match the producer
consumer pattern used by tokubackup (and eliminate the problem).
3. Fixes a concurrent open memory and file descriptor leak caused by missing
locking in the manager open function.

Tools:
Ubuntu 19.10, Clang 7,8,9, Gcc 7,8,9, Cmake 3.14

Directions:
CXXFLAGS=-fsanitize=thread CC=clang CXX=clang++ cmake -D CMAKE_BUILD_TYPE=Debug ..
make
ctest

Copyright (c) 2020, Rik Prohaska
All rights reserved.

Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.