### PR TITLE
PS-7949 - Set `-Wimplicit-fallthrough=3`

### DIFF
--- a/backup/CMakeLists.txt
+++ b/backup/CMakeLists.txt
@@ -22,6 +22,10 @@ set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS
 
 set(CMAKE_CXX_FLAGS "-Werror -W -Wall -Wshadow ${CMAKE_CXX_FLAGS}")
 
+IF(CMAKE_COMPILER_IS_GNUCXX)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wimplicit-fallthrough=3")
+ENDIF()
+
 set(USE_VALGRIND OFF CACHE BOOL "whether to use valgrind headers")
 if (USE_VALGRIND)
   set_property(DIRECTORY APPEND PROPERTY


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7949

***

PS uses the more strict value 5 which requires `--std=c++17`.

As this module is used by PS 5.7, which does not support `--std=c++17`,
the inherited value of PS must be overwritten.