### PR TITLE
Changed cmake_minimum_required VERSION to 2.8.12

### DIFF
--- a/backup/CMakeLists.txt
+++ b/backup/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/backup/tests/CMakeLists.txt
+++ b/backup/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(BackupTests)
 include_directories(..)
 find_package( Threads )


### PR DESCRIPTION
Newer CMake binaries started to generate a warning if 'cmake_minimum_required' 'VERSION' is less than '2.8.12'. Increased this 'VERSION' to suppress the warning.